### PR TITLE
fix: Android 11 Scoped Storage. style: Removed Tutorial tab from MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.sketchware.remod.sources">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -16,6 +17,8 @@
     <uses-permission android:name="com.android.vending.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
     <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+      tools:ignore="ScopedStorage" />
 
     <application
         android:name="com.besome.sketch.SketchApplication"
@@ -25,7 +28,8 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true">
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />

--- a/app/src/main/java/com/besome/sketch/MainActivity.java
+++ b/app/src/main/java/com/besome/sketch/MainActivity.java
@@ -249,7 +249,7 @@ public class MainActivity extends BasePermissionAppCompatActivity implements Vie
         D = u.a("U1I2", true);
         r = new String[]{
                 xB.b().a(this, Resources.string.main_tab_title_myproject),
-                xB.b().a(this, Resources.string.main_tab_title_tutorials)};
+                //xB.b().a(this, Resources.string.main_tab_title_tutorials)};
         l = findViewById(Resources.id.toolbar);
         a(l);
         d().d(true);
@@ -562,25 +562,27 @@ public class MainActivity extends BasePermissionAppCompatActivity implements Vie
 
         @Override // a.a.a.kk
         public int a() {
-            return 2;
+            return 1; //Was 2 with tutorials tab
         }
 
         @Override // a.a.a.gg, a.a.a.kk
         public Object a(ViewGroup viewGroup, int i) {
             Fragment fragment = (Fragment) super.a(viewGroup, i);
-            if (i == 0) {
+            y = (GC) fragment;
+
+           /* if (i == 0) {
                 y = (GC) fragment;
             } else if (i == 1) {
                 z = (zI) fragment;
-            }
+            } */
             return fragment;
         }
 
         @Override // a.a.a.gg
         public Fragment c(int i) {
-            if (i != 0) {
+          /* if (i != 0) {
                 return new zI();
-            }
+            } */
             return new GC();
         }
 


### PR DESCRIPTION
Removed the not working unused tutorial tab from MainActivity . 
Now it only contains 'MY PROJECTS'

Note : I just commented out certain parts of the PageAdapter so it won't include the tutorials tab. The fragment is still in there.

fix: Android 11 Scoped Storage Fixes.
Adding request for 'ALL FILE ACCESS' and thus read and write no longer depends on emulated SAF on Android 11 or further.
Results: No more freezing or infinite loading time when saving or building a project. 

P.S: Tested on my Device running android 11. And almost all the slowdowns are gone. It performs like older android 10 again