### PR TITLE
feat: add option to show the source code of a single activity.

### DIFF
--- a/app/src/main/java/a/a/a/yq.java
+++ b/app/src/main/java/a/a/a/yq.java
@@ -909,6 +909,17 @@ public class yq {
         CommandBlock.x();
         return srcCodeBeans;
     }
+    
+    /**
+     * Get source code of a single Activity
+     */
+    public String getActivitySrc(String javaName, hC hCVar, eC eCVar, iC iCVar){
+        a(iCVar, hCVar, eCVar, false);
+        for (ProjectFileBean activity : hCVar.b()) {
+            if (javaName.equals(activity.getJavaName())) return new Jx(N, activity, eCVar).a();
+        }
+        return "";
+    }
 
     /**
      * @see yq#a(hC, eC, iC, boolean)

--- a/app/src/main/java/a/a/a/yq.java
+++ b/app/src/main/java/a/a/a/yq.java
@@ -909,11 +909,13 @@ public class yq {
         CommandBlock.x();
         return srcCodeBeans;
     }
-    
+
     /**
      * Get source code of a single Activity
+     *
+     * @return The Activity specified by <code>javaName</code>'s source or an empty String if not found
      */
-    public String getActivitySrc(String javaName, hC hCVar, eC eCVar, iC iCVar){
+    public String getActivitySrc(String javaName, hC hCVar, eC eCVar, iC iCVar) {
         a(iCVar, hCVar, eCVar, false);
         for (ProjectFileBean activity : hCVar.b()) {
             if (javaName.equals(activity.getJavaName())) return new Jx(N, activity, eCVar).a();

--- a/app/src/main/java/com/besome/sketch/design/DesignActivity.java
+++ b/app/src/main/java/com/besome/sketch/design/DesignActivity.java
@@ -850,33 +850,33 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
     }
     
     public void showCurrentActivitySrcCode(){
-        ProgressDialog progress = new ProgressDialog(DesignActivity.this, 4);
+        ProgressDialog progress = new ProgressDialog(DesignActivity.this);
         progress.setMessage("Generating source...");
         progress.show();
+        
+        new Thread(() ->{
+            final String src = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
+            if(src.equals("")) return;
 
-        Runnable run = new Runnable() {
-            @Override
-            public void run() {
-                final String src = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
-                if(src.equals("")) return;
+            CodeEditor editor = new CodeEditor(DesignActivity.this);
+            editor.setTypefaceText(Typeface.MONOSPACE);
+            editor.setOverScrollEnabled(false);
+            editor.setEditable(false);
+            editor.setAutoCompletionEnabled(false);
+            editor.setEditorLanguage(new JavaLanguage());
+            editor.setColorScheme(new SchemeDarcula());
+            editor.setTextSize(16);
+            editor.setText(src);
 
-                CodeEditor editor = new CodeEditor(DesignActivity.this);
-                editor.setTypefaceText(Typeface.MONOSPACE);
-                editor.setOverScrollEnabled(false);
-                editor.setAutoCompletionEnabled(false);
-                editor.setEditorLanguage(new JavaLanguage());
-                editor.setColorScheme(new SchemeDarcula());
-                editor.setTextSize(16);
-                editor.setText(src);
+            AlertDialog.Builder dialog = new AlertDialog.Builder(DesignActivity.this, 4);
+            dialog.setTitle(v.g);
+            dialog.setPositiveButton("Dismiss", null);
 
-                AlertDialog.Builder dialog = new AlertDialog.Builder(DesignActivity.this);
-                DesignActivity.this.runOnUiThread(() ->{
-                    dialog.setView(editor).create().show();
-                    progress.dismiss();
-                });
-            }
-        };
-        new Thread(run).start();
+            DesignActivity.this.runOnUiThread(() ->{
+                dialog.setView(editor).create().show();
+                progress.dismiss();
+            });
+        }).start();
     }
 
     /**

--- a/app/src/main/java/com/besome/sketch/design/DesignActivity.java
+++ b/app/src/main/java/com/besome/sketch/design/DesignActivity.java
@@ -402,6 +402,7 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
                 menu.add(Menu.NONE, 1, Menu.NONE, "Build Settings");
                 menu.add(Menu.NONE, 2, Menu.NONE, "Clean temporary files");
                 menu.add(Menu.NONE, 3, Menu.NONE, "Show last compile error");
+                menu.add(Menu.NONE, 5, Menu.NONE, "Show source code");
                 if (FileUtil.isExistFile(q.H)) {
                     menu.add(Menu.NONE, 4, Menu.NONE, "Install last built APK");
                 }
@@ -426,6 +427,10 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
                             } else {
                                 SketchwareUtil.toast("APK doesn't exist anymore");
                             }
+                            break;
+                            
+                        case 5:
+                            showCurrentActivitySrcCode();
                             break;
 
                         default:
@@ -845,20 +850,33 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
     }
     
     public void showCurrentActivitySrcCode(){
-        final String src = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
-        if(src.equals("")) return;
-        
-        CodeEditor editor = new CodeEditor(DesignActivity.this);
-        editor.setTypefaceText(Typeface.MONOSPACE);
-        editor.setOverScrollEnabled(false);
-        editor.setAutoCompletionEnabled(false);
-        editor.setEditorLanguage(new JavaLanguage());
-        editor.setColorScheme(new SchemeDarcula());
-        editor.setTextSize(16);
-        editor.setText(src);
-        
-        AlertDialog.Builder dialog = new AlertDialog.Builder(DesignActivity.this);
-        dialog.setView(editor).create().show();
+        ProgressDialog progress = new ProgressDialog(DesignActivity.this, 4);
+        progress.setMessage("Generating source...");
+        progress.show();
+
+        Runnable run = new Runnable() {
+            @Override
+            public void run() {
+                final String src = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
+                if(src.equals("")) return;
+
+                CodeEditor editor = new CodeEditor(DesignActivity.this);
+                editor.setTypefaceText(Typeface.MONOSPACE);
+                editor.setOverScrollEnabled(false);
+                editor.setAutoCompletionEnabled(false);
+                editor.setEditorLanguage(new JavaLanguage());
+                editor.setColorScheme(new SchemeDarcula());
+                editor.setTextSize(16);
+                editor.setText(src);
+
+                AlertDialog.Builder dialog = new AlertDialog.Builder(DesignActivity.this);
+                DesignActivity.this.runOnUiThread(() ->{
+                    dialog.setView(editor).create().show();
+                    progress.dismiss();
+                });
+            }
+        };
+        new Thread(run).start();
     }
 
     /**

--- a/app/src/main/java/com/besome/sketch/design/DesignActivity.java
+++ b/app/src/main/java/com/besome/sketch/design/DesignActivity.java
@@ -1,11 +1,13 @@
 package com.besome.sketch.design;
 
 import android.content.Context;
+import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Build.VERSION;
 import android.os.Bundle;
@@ -107,6 +109,9 @@ import mod.jbk.util.LogUtil;
 import mod.nethical.mod.CleanAsyncTask;
 import mod.tyron.compiler.Compiler;
 import mod.tyron.compiler.IncrementalCompiler;
+import io.github.rosemoe.editor.langs.java.JavaLanguage;
+import io.github.rosemoe.editor.widget.CodeEditor;
+import io.github.rosemoe.editor.widget.schemes.SchemeDarcula;
 
 public class DesignActivity extends BaseAppCompatActivity implements OnClickListener, uo {
 
@@ -837,6 +842,23 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
         });
         dialog.setCancelable(false);
         dialog.show();
+    }
+    
+    public void showCurrentActivitySrcCode(){
+        final String src = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
+        if(src.equals("")) return;
+        
+        CodeEditor editor = new CodeEditor(DesignActivity.this);
+        editor.setTypefaceText(Typeface.MONOSPACE);
+        editor.setOverScrollEnabled(false);
+        editor.setAutoCompletionEnabled(false);
+        editor.setEditorLanguage(new JavaLanguage());
+        editor.setColorScheme(new SchemeDarcula());
+        editor.setTextSize(16);
+        editor.setText(src);
+        
+        AlertDialog.Builder dialog = new AlertDialog.Builder(DesignActivity.this);
+        dialog.setView(editor).create().show();
     }
 
     /**

--- a/app/src/main/java/com/besome/sketch/design/DesignActivity.java
+++ b/app/src/main/java/com/besome/sketch/design/DesignActivity.java
@@ -1,8 +1,10 @@
 package com.besome.sketch.design;
 
-import android.content.Context;
+import static mod.SketchwareUtil.getDip;
+
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
@@ -86,6 +88,9 @@ import a.a.a.yq;
 import dev.aldi.sayuti.editor.manage.ManageCustomAttributeActivity;
 import dev.aldi.sayuti.editor.manage.ManageLocalLibraryActivity;
 import id.indosw.mod.DirectEditorActivity;
+import io.github.rosemoe.editor.langs.java.JavaLanguage;
+import io.github.rosemoe.editor.widget.CodeEditor;
+import io.github.rosemoe.editor.widget.EditorColorScheme;
 import mod.SketchwareUtil;
 import mod.agus.jcoderz.editor.manage.background.ManageBackgroundActivity;
 import mod.agus.jcoderz.editor.manage.permission.ManagePermissionActivity;
@@ -110,9 +115,6 @@ import mod.jbk.util.LogUtil;
 import mod.nethical.mod.CleanAsyncTask;
 import mod.tyron.compiler.Compiler;
 import mod.tyron.compiler.IncrementalCompiler;
-import io.github.rosemoe.editor.langs.java.JavaLanguage;
-import io.github.rosemoe.editor.widget.CodeEditor;
-import io.github.rosemoe.editor.widget.schemes.SchemeDarcula;
 
 public class DesignActivity extends BaseAppCompatActivity implements OnClickListener, uo {
 
@@ -399,7 +401,7 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
                 PopupMenu popupMenu = new PopupMenu(this, findViewById(Resources.id.btn_compiler_opt));
                 Menu menu = popupMenu.getMenu();
 
-                // TODO: Add nice title item (that's smaller, can't be selected, etc.)
+                // TODO: Add nice title item(s) which are smaller, can't be selected, etc.
                 menu.add(Menu.NONE, 1, Menu.NONE, "Build Settings");
                 menu.add(Menu.NONE, 2, Menu.NONE, "Clean temporary files");
                 menu.add(Menu.NONE, 3, Menu.NONE, "Show last compile error");
@@ -429,7 +431,7 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
                                 SketchwareUtil.toast("APK doesn't exist anymore");
                             }
                             break;
-                            
+
                         case 5:
                             showCurrentActivitySrcCode();
                             break;
@@ -849,33 +851,39 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
         dialog.setCancelable(false);
         dialog.show();
     }
-    
-    public void showCurrentActivitySrcCode(){
+
+    private void showCurrentActivitySrcCode() {
         ProgressDialog progress = new ProgressDialog(DesignActivity.this);
         progress.setMessage("Generating source...");
         progress.show();
-        
-        new Thread(() ->{
-            final String src = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
-            if(src.equals("")) return;
 
-            CodeEditor editor = new CodeEditor(DesignActivity.this);
-            editor.setTypefaceText(Typeface.MONOSPACE);
-            editor.setOverScrollEnabled(false);
-            editor.setEditable(false);
-            editor.setAutoCompletionEnabled(false);
-            editor.setEditorLanguage(new JavaLanguage());
-            editor.setColorScheme(new SchemeDarcula());
-            editor.setTextSize(16);
-            editor.setText(src);
+        new Thread(() -> {
+            final String source = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
 
-            AlertDialog.Builder dialog = new AlertDialog.Builder(DesignActivity.this, 4);
-            dialog.setTitle(v.g);
-            dialog.setPositiveButton("Dismiss", null);
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(DesignActivity.this)
+                    .setTitle(v.g)
+                    .setPositiveButton("Dismiss", null);
 
-            DesignActivity.this.runOnUiThread(() ->{
-                dialog.setView(editor).create().show();
+            runOnUiThread(() -> {
                 progress.dismiss();
+
+                CodeEditor editor = new CodeEditor(DesignActivity.this);
+                editor.setTypefaceText(Typeface.MONOSPACE);
+                editor.setOverScrollEnabled(false);
+                editor.setEditable(false);
+                editor.setAutoCompletionEnabled(false);
+                editor.setEditorLanguage(new JavaLanguage());
+                editor.setColorScheme(new EditorColorScheme());
+                editor.setTextSize(16);
+                editor.setText(!source.equals("") ? source : "Failed to generate source.");
+
+                AlertDialog dialog = dialogBuilder.create();
+                dialog.setView(editor,
+                        (int) getDip(24),
+                        (int) getDip(8),
+                        (int) getDip(24),
+                        (int) getDip(8));
+                dialog.show();
             });
         }).start();
     }

--- a/app/src/main/java/com/besome/sketch/design/DesignActivity.java
+++ b/app/src/main/java/com/besome/sketch/design/DesignActivity.java
@@ -2,6 +2,7 @@ package com.besome.sketch.design;
 
 import android.content.Context;
 import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;


### PR DESCRIPTION
I added a new option to show Java source code of a single activity. No need to open SrcCodeViewer -which can be slow in large projects- just to see a source code of an activity anymore, all you need to do is to open the activity you want to show its source, then click on the "compiler option" button next to the "run" button and select "show source code".