### PR TITLE
style:Use fullscreen for some AlertDialog(s)

### DIFF
--- a/app/src/main/java/com/besome/sketch/design/DesignActivity.java
+++ b/app/src/main/java/com/besome/sketch/design/DesignActivity.java
@@ -866,7 +866,7 @@ public class DesignActivity extends BaseAppCompatActivity implements OnClickList
         new Thread(() -> {
             final String source = new yq(getApplicationContext(), l).getActivitySrc(v.g, jC.b(l), jC.a(l), jC.c(l));
 
-            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(DesignActivity.this)
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(DesignActivity.this , android.R.style.Theme_DeviceDefault_Light_NoActionBar)
                     .setTitle(v.g)
                     .setPositiveButton("Dismiss", null);
 

--- a/app/src/main/java/mod/hey/studios/logic/SourceCodeDialog.java
+++ b/app/src/main/java/mod/hey/studios/logic/SourceCodeDialog.java
@@ -23,7 +23,7 @@ public class SourceCodeDialog {
         codeEditor.setEditable(false);
         codeEditor.setColorScheme(new EditorColorScheme());
 
-        new AlertDialog.Builder(context)
+        new AlertDialog.Builder(context , android.R.style.Theme_DeviceDefault_Light_NoActionBar)
                 .setTitle("Source code")
                 .setIcon(Resources.drawable.code_icon)
                 .setView(codeEditor)

--- a/app/src/main/java/mod/hey/studios/project/custom_blocks/CustomBlocksDialog.java
+++ b/app/src/main/java/mod/hey/studios/project/custom_blocks/CustomBlocksDialog.java
@@ -72,8 +72,8 @@ public class CustomBlocksDialog {
             }
         }
 
-        new AlertDialog.Builder(c)
-                .setTitle("Used Custom Blocks")
+        new AlertDialog.Builder(c, android.R.style.Theme_DeviceDefault_Light_NoActionBar)
+                .setTitle("Custom Blocks In Project")
                 .setPositiveButton(Resources.string.common_word_close, null)
                 .setView(background)
                 .show();

--- a/app/src/main/java/mod/hosni/fraj/compilerlog/CompileErrorSaver.java
+++ b/app/src/main/java/mod/hosni/fraj/compilerlog/CompileErrorSaver.java
@@ -59,7 +59,7 @@ public class CompileErrorSaver {
         errorLogTxt.setTypeface(Typeface.MONOSPACE);
         scrollView.addView(errorLogTxt);
 
-        AlertDialog dialog = new AlertDialog.Builder(context)
+        AlertDialog.Builder dialog = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Light_NoActionBar)
                 .setTitle("Last compile log")
                 .setPositiveButton(Resources.string.common_word_ok, null)
                 .setNegativeButton("Clear", (dialogInterface, which) -> {


### PR DESCRIPTION
AlertDialog for viewing single source code is now using a fullscreen theme. 
Namely ```android.R.style.Theme_DeviceDefault_Light_NoActionBar```
a built in theme because I don't feel like creating a new custom theme.

I will be adding this style to as much AlertDialog possible without breaking anything.