### PR TITLE
fix: Check for storage perms before reading config

### DIFF
--- a/app/src/main/java/com/besome/sketch/MainActivity.java
+++ b/app/src/main/java/com/besome/sketch/MainActivity.java
@@ -3,6 +3,7 @@ package com.besome.sketch;
 import android.Manifest;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.net.Uri;
@@ -20,6 +21,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.content.ContextCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager.widget.ViewPager;
@@ -287,7 +289,9 @@ public class MainActivity extends BasePermissionAppCompatActivity implements Vie
             }
         }
 
-        if (!ConfigActivity.isSettingEnabled(ConfigActivity.SETTING_SKIP_MAJOR_CHANGES_REMINDER)) {
+        if ((ContextCompat.checkSelfPermission(MainActivity.this, android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) && ConfigActivity.isSettingEnabled(ConfigActivity.SETTING_SKIP_MAJOR_CHANGES_REMINDER)) {
+            return;
+        } else {
             aB dialog = new aB(this);
             dialog.b("New changes in v6.4.0");
             dialog.a("Just as a reminder; There have been many changes since v6.3.0 fix1, " +

--- a/app/src/main/java/com/besome/sketch/MainActivity.java
+++ b/app/src/main/java/com/besome/sketch/MainActivity.java
@@ -3,7 +3,6 @@ package com.besome.sketch;
 import android.Manifest;
 import android.app.AlertDialog;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.net.Uri;
@@ -21,7 +20,6 @@ import android.widget.Toast;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.core.content.ContextCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager.widget.ViewPager;
@@ -289,9 +287,7 @@ public class MainActivity extends BasePermissionAppCompatActivity implements Vie
             }
         }
 
-        if ((ContextCompat.checkSelfPermission(MainActivity.this, android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) && ConfigActivity.isSettingEnabled(ConfigActivity.SETTING_SKIP_MAJOR_CHANGES_REMINDER)) {
-            return;
-        } else {
+        if (!ConfigActivity.isSettingEnabled(ConfigActivity.SETTING_SKIP_MAJOR_CHANGES_REMINDER)) {
             aB dialog = new aB(this);
             dialog.b("New changes in v6.4.0");
             dialog.a("Just as a reminder; There have been many changes since v6.3.0 fix1, " +

--- a/app/src/main/java/mod/hilal/saif/activities/tools/ConfigActivity.java
+++ b/app/src/main/java/mod/hilal/saif/activities/tools/ConfigActivity.java
@@ -96,7 +96,7 @@ public class ConfigActivity extends Activity {
         HashMap<String, Object> settings = new Gson().fromJson(
                 FileUtil.readFile(SETTINGS_FILE.getAbsolutePath()),
                 Helper.TYPE_MAP);
-        if (settings.containsKey(keyName)) {
+        if (settings != null && settings.containsKey(keyName)) {
             Object value = settings.get(keyName);
             if (value instanceof Boolean) {
                 return (Boolean) value;


### PR DESCRIPTION
If no storage perms , don't try to read for custom config,
Fixes startup crash