### PR TITLE
fix: Use getActivity() in fragments for AlertDialog

### DIFF
--- a/app/src/main/java/a/a/a/Jx.java
+++ b/app/src/main/java/a/a/a/Jx.java
@@ -533,7 +533,7 @@ public class Jx {
                     .replaceAll("Typeface.createFromAsset\\(getAssets\\(\\)", "Typeface.createFromAsset(getContext().getAssets()")
                     .replaceAll("= getAssets\\(\\).open", "= getContext().getAssets().open")
                     .replaceAll("getSharedPreferences", "getContext().getSharedPreferences")
-                    .replaceAll("AlertDialog.Builder\\(this\\);", "AlertDialog.Builder(getContext());")
+                    .replaceAll("AlertDialog.Builder\\(this\\);", "AlertDialog.Builder(getActivity());")
                     .replaceAll("SpeechRecognizer.createSpeechRecognizer\\(this\\);", "SpeechRecognizer.createSpeechRecognizer(getContext());")
                     .replaceAll("new RequestNetwork\\(this\\);", "new RequestNetwork((Activity) getContext());")
                     .replaceAll("new BluetoothConnect\\(this\\);", "new BluetoothConnect((Activity) getContext());")


### PR DESCRIPTION
to prevent crashes like this
![image](https://user-images.githubusercontent.com/74397286/152763809-fe2d4ef5-f8b6-4334-b784-8aa8bcf76667.png)