### PR TITLE
refactor,fix: Change how application crashes are handled

### DIFF
--- a/app/src/main/assets/debug/DebugActivity.java
+++ b/app/src/main/assets/debug/DebugActivity.java
@@ -1,76 +1,63 @@
 package <?package_name?>;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.TextView;
 
 public class DebugActivity extends Activity {
-
-    private String[] exceptionTypes = {
-            "StringIndexOutOfBoundsException",
-            "IndexOutOfBoundsException",
-            "ArithmeticException",
-            "NumberFormatException",
-            "ActivityNotFoundException"
-    };
-
-    private String[] exceptionMessages = {
-            "Invalid string operation\n",
-            "Invalid list operation\n",
-            "Invalid arithmetical operation\n",
-            "Invalid toNumber block operation\n",
-            "Invalid intent operation"
-    };
+    private AlertDialog dialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        Intent intent = getIntent();
-        String errorMessage = "";
-        String madeErrorMessage = "";
-
-        if (intent != null) {
-            errorMessage = intent.getStringExtra("error");
-
-            String[] split = errorMessage.split("\n");
-            //errorMessage = split[0];
-            try {
-                for (int j = 0; j < exceptionTypes.length; j++) {
-                    if (split[0].contains(exceptionTypes[j])) {
-                        madeErrorMessage = exceptionMessages[j];
-
-                        int addIndex = split[0].indexOf(exceptionTypes[j]) + exceptionTypes[j].length();
-
-                        madeErrorMessage += split[0].substring(addIndex, split[0].length());
-                        madeErrorMessage += "\n\nDetailed error message:\n" + errorMessage;
-                        break;
-                    }
-                }
-
-                if (madeErrorMessage.isEmpty()) {
-                    madeErrorMessage = errorMessage;
-                }
-            } catch (Exception e) {
-                madeErrorMessage = madeErrorMessage + "\n\nError while getting error: " + Log.getStackTraceString(e);
-            }
-        }
-
-        AlertDialog dialog = new AlertDialog.Builder(this)
-                .setTitle("An error occurred")
-                .setMessage(madeErrorMessage)
-                .setPositiveButton("End Application", new DialogInterface.OnClickListener() {
+        dialog = new AlertDialog.Builder(this)
+                .setTitle("Crash Log")
+                .setMessage(getLastSavedErrorLog(this))
+                .setNeutralButton("Dismiss", null)
+                .setPositiveButton("Dismiss & Clear", new DialogInterface.OnClickListener() {
                     @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        finish();
+                    public void onClick(DialogInterface dialogInterface, int which) {
+                        clearErrorLog(DebugActivity.this);
                     }
                 })
                 .create();
+
+        dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialogInterface) {
+                DebugActivity.this.finish();
+            }
+        });
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialogInterface) {
+                ((TextView) dialog.findViewById(android.R.id.message)).setTextIsSelectable(true);
+            }
+        });
         dialog.show();
-        ((TextView) dialog.findViewById(android.R.id.message)).setTextIsSelectable(true);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (dialog != null && dialog.isShowing())
+            dialog.dismiss();
+    }
+
+    @SuppressLint("ApplySharedPref")
+    public static void saveErrorLog(Context context, String errorLog) {
+        context.getSharedPreferences("SK_CRASH_LOG", Context.MODE_PRIVATE).edit().putString("errorLog", errorLog).commit();
+    }
+
+    public static void clearErrorLog(Context context) {
+        context.getSharedPreferences("SK_CRASH_LOG", Context.MODE_PRIVATE).edit().remove("errorLog").apply();
+    }
+
+    public static String getLastSavedErrorLog(Context context) {
+        return context.getSharedPreferences("SK_CRASH_LOG", Context.MODE_PRIVATE).getString("errorLog", "");
     }
 }

--- a/app/src/main/assets/debug/SketchApplication.java
+++ b/app/src/main/assets/debug/SketchApplication.java
@@ -1,11 +1,8 @@
 package <?package_name?>;
 
-import android.app.AlarmManager;
 import android.app.Application;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Process;
 import android.util.Log;
 
 public class SketchApplication extends Application {
@@ -20,33 +17,21 @@ public class SketchApplication extends Application {
     @Override
     public void onCreate() {
         mApplicationContext = getApplicationContext();
-        this.uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
 
-        Thread.setDefaultUncaughtExceptionHandler(
-            new Thread.UncaughtExceptionHandler() {
-                @Override
-                public void uncaughtException(Thread thread, Throwable throwable) {
-                    Intent intent = new Intent(getApplicationContext(), DebugActivity.class);
-                    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                    intent.putExtra("error", Log.getStackTraceString(throwable));
+        // Setup handler for uncaught exceptions.
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread thread, Throwable throwable) {
+                throwable.printStackTrace();
+                DebugActivity.saveErrorLog(SketchApplication.this.getApplicationContext(), Log.getStackTraceString(throwable));
+                System.exit(1);
+            }
+        });
 
-                    PendingIntent pendingIntent =
-                        PendingIntent.getActivity(
-                            getApplicationContext(),
-                            11111,
-                            intent,
-                            PendingIntent.FLAG_ONE_SHOT
-                        );
+        //Look for saved crash logs and show them
+        if (!DebugActivity.getLastSavedErrorLog(getApplicationContext()).isEmpty())
+            startActivity(new Intent(getApplicationContext(), DebugActivity.class).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
 
-                    AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
-                    am.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, 1000, pendingIntent);
-
-                    Process.killProcess(Process.myPid());
-                    System.exit(1);
-
-                    uncaughtExceptionHandler.uncaughtException(thread, throwable);
-                }
-            });
         super.onCreate();
     }
 }

--- a/app/src/main/java/a/a/a/yq.java
+++ b/app/src/main/java/a/a/a/yq.java
@@ -529,14 +529,17 @@ public class yq {
                 sketchApplicationFileContent = sketchApplicationFileContent.replaceAll(
                         "Application \\{", "androidx.multidex.MultiDexApplication \\{");
             }
+
             if (logCatEnabled) {
                 sketchApplicationFileContent = sketchApplicationFileContent.replace(
-                        "super.onCreate();", "SketchLogger.startLogging();\n" +
-                                "        super.onCreate();").replace(
-                        "Process.killProcess(Process.myPid());",
-                        "                SketchLogger.broadcastLog(Log.getStackTraceString(throwable));\n" +
-                                "                SketchLogger.stopLogging();\n" + "Process.killProcess(Process.myPid());"
-                );
+                                "super.onCreate();",
+                                "SketchLogger.startLogging();\n"
+                                        + "        super.onCreate();")
+                        .replace("System.exit(1);",
+                                "SketchLogger.broadcastLog(Log.getStackTraceString(throwable));\n"
+                                        + "             SketchLogger.stopLogging();\n"
+                                        + "             System.exit(1);"
+                        );
             }
 
             L.b(y + File.separator

--- a/app/src/main/java/com/besome/sketch/DebugActivity.java
+++ b/app/src/main/java/com/besome/sketch/DebugActivity.java
@@ -1,29 +1,47 @@
 package com.besome.sketch;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.Intent;
+import android.content.Context;
 import android.os.Bundle;
 import android.widget.TextView;
 
 public class DebugActivity extends Activity {
+    private AlertDialog dialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Intent intent = getIntent();
-        if (intent != null) {
-            String error = intent.getStringExtra("error");
+        dialog = new AlertDialog.Builder(this)
+                .setTitle("Crash Log")
+                .setMessage(getLastSavedErrorLog(this))
+                .setNeutralButton("Dismiss", null)
+                .setPositiveButton("Dismiss & Clear", (dialogInterface, which) -> clearErrorLog(this))
+                .create();
 
-            if (error != null) {
-                AlertDialog dialog = new AlertDialog.Builder(this)
-                        .setTitle("An error occurred")
-                        .setMessage(error)
-                        .setPositiveButton("End Application", (dialog1, which) -> finish())
-                        .create();
-                dialog.show();
-                ((TextView) dialog.findViewById(android.R.id.message)).setTextIsSelectable(true);
-            }
-        }
+        dialog.setOnDismissListener(dialogInterface -> finish());
+        dialog.setOnShowListener(dialogInterface -> ((TextView) dialog.findViewById(android.R.id.message)).setTextIsSelectable(true));
+        dialog.show();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (dialog != null && dialog.isShowing())
+            dialog.dismiss();
+    }
+
+    @SuppressLint("ApplySharedPref")
+    public static void saveErrorLog(Context context, String errorLog) {
+        context.getSharedPreferences("SK_CRASH_LOG", Context.MODE_PRIVATE).edit().putString("errorLog", errorLog).commit();
+    }
+
+    public static void clearErrorLog(Context context) {
+        context.getSharedPreferences("SK_CRASH_LOG", Context.MODE_PRIVATE).edit().remove("errorLog").apply();
+    }
+
+    public static String getLastSavedErrorLog(Context context) {
+        return context.getSharedPreferences("SK_CRASH_LOG", Context.MODE_PRIVATE).getString("errorLog", "");
     }
 }

--- a/app/src/main/java/com/besome/sketch/SketchApplication.java
+++ b/app/src/main/java/com/besome/sketch/SketchApplication.java
@@ -1,11 +1,8 @@
 package com.besome.sketch;
 
-import android.app.AlarmManager;
 import android.app.Application;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Process;
 import android.util.Log;
 
 import com.google.android.gms.analytics.Tracker;
@@ -25,24 +22,18 @@ public class SketchApplication extends Application {
     @Override
     public void onCreate() {
         mApplicationContext = getApplicationContext();
-        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
-        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
-            Log.e("SketchApplication", "Uncaught exception on thread " + thread.getName(), throwable);
 
-            Intent intent = new Intent(getApplicationContext(), DebugActivity.class);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-            intent.putExtra("error", Log.getStackTraceString(throwable));
-            ((AlarmManager) getSystemService(Context.ALARM_SERVICE))
-                    .set(AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                            1000,
-                            PendingIntent.getActivity(getApplicationContext(), 11111, intent,
-                                    PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE));
-            Process.killProcess(Process.myPid());
+        // Setup handler for uncaught exceptions.
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            throwable.printStackTrace();
+            DebugActivity.saveErrorLog(getContext(), Log.getStackTraceString(throwable));
             System.exit(1);
-            if (uncaughtExceptionHandler != null) {
-                uncaughtExceptionHandler.uncaughtException(thread, throwable);
-            }
         });
+
+        //Look for saved crash logs and show them
+        if (!DebugActivity.getLastSavedErrorLog(getContext()).isEmpty())
+            startActivity(new Intent(getContext(), DebugActivity.class).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+
         super.onCreate();
     }
 }


### PR DESCRIPTION
Improve DebugActivity and UncaughtException Behavior.
AlarmManager fails on most of devices, So let's not use it.

Saving the crash log to a SharedPreference and showing it on next startup is most likely a better approach.