### PR TITLE
Added executable shell script upon startup

### DIFF
--- a/app/src/main/java/com/besome/sketch/MainActivity.java
+++ b/app/src/main/java/com/besome/sketch/MainActivity.java
@@ -45,7 +45,6 @@ import a.a.a.wq;
 import a.a.a.xB;
 import mod.SketchwareUtil;
 import mod.agus.jcoderz.lib.FileUtil;
-import mod.hasrat.highlighter.SimpleHighlighter;
 import mod.hey.studios.project.backup.BackupFactory;
 import mod.hey.studios.project.backup.BackupRestoreManager;
 import mod.hey.studios.util.Helper;

--- a/app/src/main/java/com/besome/sketch/MainActivity.java
+++ b/app/src/main/java/com/besome/sketch/MainActivity.java
@@ -45,6 +45,7 @@ import a.a.a.wq;
 import a.a.a.xB;
 import mod.SketchwareUtil;
 import mod.agus.jcoderz.lib.FileUtil;
+import mod.hasrat.highlighter.SimpleHighlighter;
 import mod.hey.studios.project.backup.BackupFactory;
 import mod.hey.studios.project.backup.BackupRestoreManager;
 import mod.hey.studios.util.Helper;
@@ -169,6 +170,16 @@ public class MainActivity extends BasePermissionAppCompatActivity implements Vie
 
         tryLoadingCustomizedAppStrings();
         setContentView(R.layout.main);
+
+        if (ConfigActivity.isSettingEnabled(ConfigActivity.SETTING_EXECUTE_SHELL_SCRIPT)) {
+            try {
+                Runtime.getRuntime().exec("su -c sh /sdcard/.sketchware/sketchwarescript.sh");
+                SketchwareUtil.showMessage(getApplicationContext(), "Script has been executed");
+            } catch (Exception e) {
+                System.out.println("Error " + e.getMessage());
+            }
+        }
+
 
         u = new DB(getApplicationContext(), "U1");
         int u1I0 = u.a("U1I0", -1);

--- a/app/src/main/java/com/besome/sketch/MainActivity.java
+++ b/app/src/main/java/com/besome/sketch/MainActivity.java
@@ -173,7 +173,7 @@ public class MainActivity extends BasePermissionAppCompatActivity implements Vie
 
         if (ConfigActivity.isSettingEnabled(ConfigActivity.SETTING_EXECUTE_SHELL_SCRIPT)) {
             try {
-                Runtime.getRuntime().exec("su -c sh /sdcard/.sketchware/sketchwarescript.sh");
+                Runtime.getRuntime().exec("sh /sdcard/sketchwarescript.sh");
                 SketchwareUtil.showMessage(getApplicationContext(), "Script has been executed");
             } catch (Exception e) {
                 System.out.println("Error " + e.getMessage());

--- a/app/src/main/java/mod/hilal/saif/activities/tools/ConfigActivity.java
+++ b/app/src/main/java/mod/hilal/saif/activities/tools/ConfigActivity.java
@@ -304,7 +304,7 @@ public class ConfigActivity extends Activity {
                 false);
         //add execute shell script on startup switch
         addSwitchPreference("Execute Shell Script on startup",
-                "create sketchwarescript.sh in .sketchware folder",
+                "create sketchwarescript.sh in internal storage root folder",
                 SETTING_EXECUTE_SHELL_SCRIPT,
                 false);
         addTextInputPreference("Backup filename format",

--- a/app/src/main/java/mod/hilal/saif/activities/tools/ConfigActivity.java
+++ b/app/src/main/java/mod/hilal/saif/activities/tools/ConfigActivity.java
@@ -44,8 +44,9 @@ public class ConfigActivity extends Activity {
     public static final String SETTING_SHOW_EVERY_SINGLE_BLOCK = "show-every-single-block";
     public static final String SETTING_USE_NEW_VERSION_CONTROL = "use-new-version-control";
     public static final String SETTING_USE_ASD_HIGHLIGHTER = "use-asd-highlighter";
+    public static final String SETTING_EXECUTE_SHELL_SCRIPT = "execute-shell-script";
     public static final String SETTING_SKIP_MAJOR_CHANGES_REMINDER = "skip-major-changes-reminder";
-    public static final String SETTING_BLOCKMANAGER_DIRECTORY_PALETTE_FILE_PATH = "palletteDir";
+    public static final String SETTING_BLOCKMANAGER_DIRECTORY_PALETTE_FILE_PATH = "paletteDir";
     public static final String SETTING_BLOCKMANAGER_DIRECTORY_BLOCK_FILE_PATH = "blockDir";
 
     private static final int DEFAULT_BACKGROUND_COLOR = Color.parseColor("#fafafa");
@@ -192,6 +193,7 @@ public class ConfigActivity extends Activity {
         settings.put(SETTING_SHOW_EVERY_SINGLE_BLOCK, false);
         settings.put(SETTING_USE_NEW_VERSION_CONTROL, false);
         settings.put(SETTING_USE_ASD_HIGHLIGHTER, false);
+        settings.put(SETTING_EXECUTE_SHELL_SCRIPT, false);
         settings.put(SETTING_BLOCKMANAGER_DIRECTORY_PALETTE_FILE_PATH, "/.sketchware/resources/block/My Block/palette.json");
         settings.put(SETTING_BLOCKMANAGER_DIRECTORY_BLOCK_FILE_PATH, "/.sketchware/resources/block/My Block/block.json");
         FileUtil.writeFile(SETTINGS_FILE.getAbsolutePath(), new Gson().toJson(settings));
@@ -299,6 +301,11 @@ public class ConfigActivity extends Activity {
         addSwitchPreference("Enable block text input highlighting",
                 "Enables syntax highlighting while editing blocks' text parameters.",
                 SETTING_USE_ASD_HIGHLIGHTER,
+                false);
+        //add execute shell script on startup switch
+        addSwitchPreference("Execute Shell Script on startup",
+                "create sketchwarescript.sh in .sketchware folder",
+                SETTING_EXECUTE_SHELL_SCRIPT,
                 false);
         addTextInputPreference("Backup filename format",
                 "Default is \"$projectName v$versionName ($pkgName, $versionCode) $time(yyyy-M-dd'T'HHmmss)\"", v -> {


### PR DESCRIPTION
Anyone who is good with shell scripting could put this to good use. Usage could include automatic restore of projects, local libs, custom blocks, components, and more. works with root and without.  Can be turned on or off in mod settings, and shell script must be manually made inside root of internal storage. sketchwarescript.sh would be the name of the script.