### PR TITLE
update firebase version to 19.3.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,29 +9,20 @@ android {
 
     def gitCommitHash = "git rev-parse HEAD".execute().text.trim()
 
-    def getCommitHash = { ->
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine "git", "rev-parse", "--short", "HEAD"
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    }
-
     defaultConfig {
         applicationId "com.sketchware.remod"
         namespace "com.sketchware.remod"
         //noinspection ExpiredTargetSdkVersion since we don't target getting Sketchware Pro on Google Play.
         targetSdkVersion 28
         versionCode 150
-        versionName "v6.4.0-SNAPSHOT-" + getCommitHash()
+        versionName "v6.4.0-rc04"
 
         buildConfigField("String", "GIT_HASH", "\"${gitCommitHash}\"")
 
         buildConfigField("String", "FLAVOR_NAME_WITH_AABS", "\"minApi26\"")
         buildConfigField("String", "FLAVOR_NAME_WITHOUT_AABS", "\"minApi21\"")
 
-        buildConfigField("String", "VERSION_NAME_WITHOUT_FLAVOR", "\"v6.4.0-SNAPSHOT-${getCommitHash()}\"")
+        buildConfigField("String", "VERSION_NAME_WITHOUT_FLAVOR", "\"v6.4.0-rc04\"")
     }
 
     flavorDimensions "api"


### PR DESCRIPTION
With firebase version 19.3.0 we will be able to use increment values ​​to send data to the database easily and you can also use the write timestamp

This change takes no more than 3 lines of code and won't mess up old projects before this change.

In this way we will be able to use the methods:
ServerValue.TIMESTAMP
ServerValue.increment(0)

Example:
send.put("balance", ServerValue.increment(1));
send.put("timestamps", ServerValue.TIMESTAMP);
Db.path("users/uid).update(send);

import com.google.firebase.database.ServerValue; 

Note: I already made the modification using the latest version and it worked without problems, follow the video of how I did it to edit the mod 
https://drive.google.com/file/d/1PdvlJ_PlPtWpQwMGXjFlEXYXO5Iwp3N6/view