### PR TITLE
Lib Version Update as same as Sketchware pro

### DIFF
--- a/app/src/main/java/a/a/a/Lx.java
+++ b/app/src/main/java/a/a/a/Lx.java
@@ -59,8 +59,8 @@ public class Lx {
                 "implementation fileTree(dir: 'libs', include: ['*.jar'])\r\n";
 
         if (metadata.g) {
-            content += "implementation 'androidx.appcompat:appcompat:1.2.0'\r\n" +
-                    "implementation 'com.google.android.material:material:1.4.0'\r\n";
+            content += "implementation 'androidx.appcompat:appcompat:1.4.0'\r\n" +
+                    "implementation 'com.google.android.material:material:1.6.1'\r\n";
         }
 
         if (metadata.isFirebaseAuthUsed) {


### PR DESCRIPTION
com.google.android.material > 1.6.1
androidx.appcompat > 1.4.0

Exported source code using older lib than Sketchware pro run fix.