### PR TITLE
fix: Images not loading in about screen in old android versions

### DIFF
--- a/app/src/main/res/layout/about_changelog.xml
+++ b/app/src/main/res/layout/about_changelog.xml
@@ -49,7 +49,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
                 android:layout_marginBottom="10dp"
-                app:cardCornerRadius="100dp">
+                app:cardCornerRadius="22.2dp">
 
                 <ImageView
                     android:id="@+id/img_user_icon"

--- a/app/src/main/res/layout/about_moddersview.xml
+++ b/app/src/main/res/layout/about_moddersview.xml
@@ -42,7 +42,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:layout_marginBottom="10dp"
-            app:cardCornerRadius="100dp">
+            app:cardCornerRadius="22.2dp">
 
             <ImageView
                 android:id="@+id/img_user_icon"


### PR DESCRIPTION
I fixed an issue happening in old android (before android 7), the images at about screen had shandows but not images. 

# Before:
![Screenshot_2023-04-29-15-39-17](https://user-images.githubusercontent.com/103432992/235302959-75c87362-a233-4e0c-904a-47499e1bc0bb.jpg)

# After:
![Screenshot_2023-04-29-15-27-08](https://user-images.githubusercontent.com/103432992/235302985-377a7de6-82c9-4555-865e-eae01cb03cba.jpg)
