### PR TITLE
Fix a rare crash with parsing maven metadata

### DIFF
--- a/app/src/main/java/mod/pranav/dependency/resolver/DependencyResolver.kt
+++ b/app/src/main/java/mod/pranav/dependency/resolver/DependencyResolver.kt
@@ -204,7 +204,7 @@ class DependencyResolver(
                 callback.log("Fetching latest version of ${dep.artifactId}")
                 val factory = DocumentBuilderFactory.newInstance()
                 val builder = factory.newDocumentBuilder()
-                val doc = builder.parse(dep.getMavenMetadata())
+                val doc = builder.parse(dep.getMavenMetadata().byteInputStream())
                 val v = doc.getElementsByTagName("release").item(0)
                 if (v != null) {
                     dep.version = v.textContent


### PR DESCRIPTION
Fixes random unexpected crashes while parsing maven metadata on some cases

Reproduction dependencies:
org.apache.maven:maven-artifact:3.8.1

Source: https://stackoverflow.com/a/16299661