### PR TITLE
fix: Now the javascript functions are not in conflict with proguard

### DIFF
--- a/app/src/main/java/mod/hey/studios/project/proguard/ProguardHandler.java
+++ b/app/src/main/java/mod/hey/studios/project/proguard/ProguardHandler.java
@@ -86,6 +86,10 @@ public class ProguardHandler {
                     "    @android.support.annotation.Keep <init>(...);\n" +
                     "}\n" +
                     "\n" +
+                    "-keepclassmembers class * {\n" +
+                    "    @android.webkit.JavascriptInterface <methods>;" +
+                    "}\n" +
+                    "\n" +
                     "-dontwarn android.arch.**\n" +
                     "-dontwarn android.lifecycle.**\n" +
                     "-keep class android.arch.** { *; }\n" +


### PR DESCRIPTION
This fix allows the use of @JavascriptInterface methods without removing the protection of evals.