### PR TITLE
Bump iyxan23/zipalign-java to v1.1.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     //noinspection GradleDependency
     implementation "com.android.tools:sdklib:25.3.0", { exclude group: "com.intellij", module: "annotations" }
     implementation "com.android.tools:r8:8.0.40"
-    implementation "com.github.Iyxan23:zipalign-java:1.1.1"
+    implementation "com.github.Iyxan23:zipalign-java:1.1.2"
 
     implementation "com.google.code.gson:gson:2.10.1"
     implementation "com.madgag:scpkix-jdk15on:1.47.0.2"


### PR DESCRIPTION
A patch update that fixes overflowing issues for apk with a lot of large `.so` files.