### PR TITLE
fix view colors on BuildSettingsDialog

### DIFF
--- a/app/src/main/java/mod/hey/studios/build/BuildSettingsDialog.java
+++ b/app/src/main/java/mod/hey/studios/build/BuildSettingsDialog.java
@@ -151,7 +151,6 @@ public class BuildSettingsDialog {
 
     private EditText addInputPref(String key, String defaultValue, String hint, int inputType, LinearLayout addTo) {
         TextInputLayout textInputLayout = new TextInputLayout(activity);
-
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -161,9 +160,7 @@ public class BuildSettingsDialog {
                 0,
                 0
         );
-
         textInputLayout.setLayoutParams(layoutParams);
-
         addTo.addView(textInputLayout);
 
         EditText editText = new EditText(activity);
@@ -179,7 +176,7 @@ public class BuildSettingsDialog {
         editText.setTextSize(16f);
         editText.setTextColor(ThemeUtils.getColor(editText, R.attr.colorOnSurface));
         editText.setHint(hint);
-        editText.setHintTextColor(ThemeUtils.getColor(editText, R.attr.colorOnSurfaceVariant));
+        editText.setHintTextColor(ThemeUtils.getColor(editText, R.attr.colorPrimary));
         editText.setText(settings.getValue(key, defaultValue));
         editText.setTag(key);
         editText.setInputType(inputType);


### PR DESCRIPTION
fix view colors on BuildSettingsDialog and add a class to "facilitate" the use of TextInputLayout & TextInputEditText  in java or kt class 

See:


![Screenshot_20240823-005223_Sketchware Pro](https://github.com/user-attachments/assets/948095e5-0d40-4f94-b0fb-dc64f69606a7)
![Screenshot_20240823-005241_Sketchware Pro](https://github.com/user-attachments/assets/bf7b0ef3-5e1b-485c-803f-4ad1a9dd5d8e)
