### PR TITLE
fix: Crash when adding a new component in certain cases

### DIFF
--- a/app/src/main/java/a/a/a/br.java
+++ b/app/src/main/java/a/a/a/br.java
@@ -361,6 +361,11 @@ public class br extends qA implements View.OnClickListener {
                     holder.button.onEventAdded();
                     holder.button.getName().setText(event.eventName);
                     holder.button.getIcon().setImageResource(oq.a(event.eventName));
+                    holder.button.setClickListener(v -> {
+                        if (!mB.a()) {
+                            openEvent(event.targetId, event.eventName, event.eventName);
+                        }
+                    });
                 }
             }
 
@@ -394,6 +399,24 @@ public class br extends qA implements View.OnClickListener {
                     holder.button.onEventAvailableToAdd();
                     holder.button.getName().setText(eventName);
                     holder.button.getIcon().setImageResource(oq.a(eventName));
+                    holder.button.setClickListener(v -> {
+                        if (!mB.a()) {
+                            var component = components.get(ViewHolder.this.getLayoutPosition());
+                            var event = new EventBean(EventBean.EVENT_TYPE_COMPONENT, component.type, component.componentId, eventName);
+                            jC.a(sc_id).a(projectFile.getJavaName(), event);
+                            bB.a(requireContext(), xB.b().a(requireContext(), R.string.event_message_new_event), 0).show();
+                            holder.button.onEventAdded();
+                            
+                            var newAddedEvents = new ArrayList<>(addedEventsAdapter.getCurrentList());
+                            newAddedEvents.add(event);
+                            addedEventsAdapter.submitList(newAddedEvents);
+                            
+                            var newAvailableEvents = new ArrayList<>(availableEventsAdapter.getCurrentList());
+                            newAvailableEvents.remove(eventName);
+                            availableEventsAdapter.submitList(newAvailableEvents);
+                            openEvent(event.targetId, event.eventName, event.eventName);
+                        }
+                    });
                 }
             }
 
@@ -403,31 +426,6 @@ public class br extends qA implements View.OnClickListener {
                 public EventViewHolder(@NonNull ComponentEventButton itemView) {
                     super(itemView);
                     button = itemView;
-                    button.setClickListener(v -> {
-                        if (!mB.a()) {
-                            EventBean event;
-                            var bindingAdapter = getBindingAdapter();
-                            if (bindingAdapter instanceof AddedEventsAdapter) {
-                                event = addedEventsAdapter.getCurrentList().get(getBindingAdapterPosition());
-                            } else {
-                                var component = components.get(ViewHolder.this.getLayoutPosition());
-                                var eventName = availableEventsAdapter.getCurrentList().get(getBindingAdapterPosition());
-                                event = new EventBean(EventBean.EVENT_TYPE_COMPONENT, component.type, component.componentId, eventName);
-                                jC.a(sc_id).a(projectFile.getJavaName(), event);
-                                bB.a(requireContext(), xB.b().a(requireContext(), R.string.event_message_new_event), 0).show();
-                                button.onEventAdded();
-
-                                var newAddedEvents = new ArrayList<>(addedEventsAdapter.getCurrentList());
-                                newAddedEvents.add(event);
-                                addedEventsAdapter.submitList(newAddedEvents);
-
-                                var newAvailableEvents = new ArrayList<>(availableEventsAdapter.getCurrentList());
-                                newAvailableEvents.remove(eventName);
-                                availableEventsAdapter.submitList(newAvailableEvents);
-                            }
-                            openEvent(event.targetId, event.eventName, event.eventName);
-                        }
-                    });
                 }
             }
         }


### PR DESCRIPTION
This update might fix the crash when adding a new component event. I moved the code to their adapter, so it no longer depends on checking the type with instanceof. This should make the event more reliable.