### PR TITLE
Fix AppCompat Injection Manager

### DIFF
--- a/app/src/main/java/dev/aldi/sayuti/editor/injection/AddCustomAttributeActivity.java
+++ b/app/src/main/java/dev/aldi/sayuti/editor/injection/AddCustomAttributeActivity.java
@@ -171,11 +171,11 @@ public class AddCustomAttributeActivity extends AppCompatActivity {
                     popupMenu.getMenu().add(Menu.NONE, 1, Menu.NONE, "Delete");
                 }
                 popupMenu.setOnMenuItemClickListener(item -> {
+                    int originalPosition = injections.indexOf(filtered.get(position));
+
                     if (item.getItemId() == 0) {
-                        dialog("edit", position);
+                        dialog("edit", originalPosition);
                     } else {
-                        int originalPosition = injections.indexOf(filtered.get(position));
-                        
                         if (originalPosition != -1) {
                             injections.remove(originalPosition);
                             filtered.remove(position);


### PR DESCRIPTION
This pull request resolves an `issue` with the AppCompat Injection Manager, where the edit dialog would always modify "Toolbar attributes" `regardless of the selected one` . This issue has been `fixed` by using `originalPosition`, similar to the existing logic in the delete function, to accurately locate and edit the correct attribute.