### PR TITLE
fix: crash when using loop block in `a.a.a.Fx`

### DIFF
--- a/app/src/main/java/a/a/a/Fx.java
+++ b/app/src/main/java/a/a/a/Fx.java
@@ -209,7 +209,12 @@ public class Fx {
                 break;
             case "repeat":
                 stack = bean.subStack1;
-                opcode = String.format("for(int _repeat%d = 0; _repeat%d < (int)(%s); _repeat%d++) {\r\n%s\r\n}", bean.id, bean.id, params.get(0), bean.id, stack >= 0 ? a(String.valueOf(stack), "") : "");
+                opcode = String.format("""
+                                for(int _repeat%s = 0; _repeat%s < (int)(%s); _repeat%s++) {
+                                %s
+                                }""",
+                        bean.id, bean.id, params.get(0), bean.id,
+                        stack >= 0 ? a(String.valueOf(stack), "") : "");
                 break;
             case "if":
                 stack = bean.subStack1;


### PR DESCRIPTION
Replaced `%d` with `%s` for proper formatting of `String` (`bean.id`) in the loop block, preventing `crashes` while showing the source code or building the project