### PR TITLE
fix: add missing source generation for `setCustomViewData` `cases` in `a.a.a.Fx`

### DIFF
--- a/app/src/main/java/a/a/a/Fx.java
+++ b/app/src/main/java/a/a/a/Fx.java
@@ -851,7 +851,7 @@ public class Fx {
                 opcode = String.format("%s.isLooping()", params.get(0));
                 break;
             case "soundpoolCreate":
-                opcode = String.format("%s = new SoundPool((int)(%s), AudioManager.STREAM_MUSIC, 0)", params.get(0), params.get(1));
+                opcode = String.format("%s = new SoundPool((int)(%s), AudioManager.STREAM_MUSIC, 0);", params.get(0), params.get(1));
                 break;
             case "soundpoolLoad":
                 opcode = String.format("%s.load(getApplicationContext(), R.raw.%s, 1)", params.get(0), params.get(1));
@@ -861,7 +861,7 @@ public class Fx {
 
                 break;
             case "soundpoolStreamStop":
-                opcode = String.format("%s.stop((int)(%s))", params.get(0), params.get(1));
+                opcode = String.format("%s.stop((int)(%s));", params.get(0), params.get(1));
                 break;
             case "setThumbResource":
                 name = params.get(1).replaceAll("\\.9", "");

--- a/app/src/main/java/a/a/a/Fx.java
+++ b/app/src/main/java/a/a/a/Fx.java
@@ -577,6 +577,10 @@ public class Fx {
             case "listSetData":
                 opcode = String.format("%s.setAdapter(new ArrayAdapter<String>(getBaseContext(), android.R.layout.simple_list_item_1, %s));", params.get(0), params.get(1));
                 break;
+            case "listSetCustomViewData":
+            case "recyclerSetCustomViewData":
+            case "spnSetCustomViewData":
+            case "pagerSetCustomViewData":
             case "gridSetCustomViewData":
                 opcode = String.format("%s.setAdapter(new %s(%s));", params.get(0), Lx.a(params.get(0)), params.get(1));
                 break;


### PR DESCRIPTION
Adds missing source generation cases for custom view data (with example image included)
![bug](https://github.com/user-attachments/assets/8140c629-3470-44e6-b623-839df225c84e)
