### PR TITLE
fix : Temporairly disable emoji2 initializer at startup

### DIFF
--- a/app/src/main/java/a/a/a/Ix.java
+++ b/app/src/main/java/a/a/a/Ix.java
@@ -239,7 +239,7 @@ public class Ix {
 
     private void writeAndroidxStartupInitializationProvider(XmlBuilder application) {
         var initializers = Set.of(
-                new Pair<>(builtInLibraryManager.containsLibrary(BuiltInLibraries.ANDROIDX_EMOJI2), "androidx.emoji2.text.EmojiCompatInitializer"),
+                //new Pair<>(builtInLibraryManager.containsLibrary(BuiltInLibraries.ANDROIDX_EMOJI2), "androidx.emoji2.text.EmojiCompatInitializer"),
                 new Pair<>(builtInLibraryManager.containsLibrary(BuiltInLibraries.ANDROIDX_LIFECYCLE_PROCESS), "androidx.lifecycle.ProcessLifecycleInitializer"),
                 new Pair<>(builtInLibraryManager.containsLibrary(BuiltInLibraries.ANDROIDX_WORK_RUNTIME), "androidx.work.WorkManagerInitializer")
         );


### PR DESCRIPTION
Temp fix For apk forceclose when Emoji2 startup initialization found in AndroidManifest