### PR TITLE
Fix list widget custom view in Direct XML Editor

### DIFF
--- a/app/src/main/java/a/a/a/Ox.java
+++ b/app/src/main/java/a/a/a/Ox.java
@@ -424,6 +424,19 @@ public class Ox {
                 }
             }
         }
+        // Adding tools:listitem allows the direct XML editor to recognize the customView
+        // for ListView, GridView, Spinner, or RecyclerView.
+        if ((viewBean.getClassInfo().b("ListView")
+                || viewBean.getClassInfo().b("GridView")
+                || viewBean.getClassInfo().b("Spinner")
+                || viewBean.getClassInfo().b("RecyclerView")
+                || viewBean.getClassInfo().b("ViewPager"))
+                && !injectHandler.contains("listitem")) {
+            var customView = viewBean.customView;
+            if (customView != null && !customView.isEmpty() && !customView.equals("none")) {
+                widgetTag.addAttribute("tools", "listitem", "@layout/" + customView);
+            }
+        }
         nx.a(widgetTag);
     }
 

--- a/app/src/main/java/pro/sketchware/tools/ViewBeanFactory.java
+++ b/app/src/main/java/pro/sketchware/tools/ViewBeanFactory.java
@@ -134,8 +134,26 @@ public class ViewBeanFactory {
                     bean.parentAttributes.put(attrName, parseReferName(attrValue, "/"));
                     continue;
                 }
+                if (attrName.equals("tools:listitem")) {
+                    continue;
+                }
                 // add attributes for inject property
                 injectAttributes.put(attrName, attrValue);
+            }
+        }
+        if (bean.getClassInfo().b("ListView")
+                || bean.getClassInfo().b("GridView")
+                || bean.getClassInfo().b("Spinner")
+                || bean.getClassInfo().b("RecyclerView")
+                || bean.getClassInfo().b("ViewPager")) {
+            var customView = attributes.getOrDefault("tools:listitem", null);
+            if (customView != null) {
+                if (customView.startsWith("@layout/")) {
+                    var layoutName = parseReferName(customView, "/");
+                    bean.customView = !layoutName.isEmpty() ? layoutName : "none";
+                } else {
+                    injectAttributes.put("tools:listitem", customView);
+                }
             }
         }
 


### PR DESCRIPTION
This change fixes parsing in the XML editor for list widgets like RecyclerView by using the tools:listitem attribute it'll recognize listitem as the customView.