### PR TITLE
feat: MaterialButtonToggleGroup.

### DIFF
--- a/app/src/main/res/layout/icon_creator_activity.xml
+++ b/app/src/main/res/layout/icon_creator_activity.xml
@@ -148,16 +148,9 @@
                         android:textSize="16sp"
                         android:textStyle="bold" />
 
-                    <HorizontalScrollView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center"
-                        android:requiresFadingEdge="horizontal"
-                        android:scrollbars="none">
-
                         <com.google.android.material.button.MaterialButtonToggleGroup
                             android:id="@+id/bg_type"
-                            android:layout_width="wrap_content"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginHorizontal="4dp"
                             android:layout_marginTop="10dp"
@@ -169,20 +162,20 @@
                             <Button
                                 android:id="@+id/bg_color"
                                 style="?attr/materialButtonOutlinedStyle"
-                                android:layout_width="wrap_content"
+                                android:layout_width="0dp"
                                 android:layout_height="wrap_content"
-                                android:text="Color" />
+                                android:text="Color"
+                                android:layout_weight="1"/>
 
                             <Button
                                 android:id="@+id/bg_gradient"
                                 style="?attr/materialButtonOutlinedStyle"
-                                android:layout_width="wrap_content"
+                                android:layout_width="0dp"
                                 android:layout_height="wrap_content"
-                                android:text="Gradient" />
-
-
+                                android:text="Gradient"
+                                android:layout_weight="1"/>
                         </com.google.android.material.button.MaterialButtonToggleGroup>
-                    </HorizontalScrollView>
+
 
                     <LinearLayout
                         android:id="@+id/linear_clr"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/59d38568-7e36-470f-8de5-e87bf7502a29)![image](https://github.com/user-attachments/assets/0ff8bd52-1c09-46bd-9ac4-4f8ee19b122c)

- The HorizontalScrollView that previously wrapped the background selection buttons (bg_type) has been removed, which eliminates horizontal scrolling. The scroll is unnecessary as there are only two options, they would never leave the layout.

- The width of the MaterialButtonToggleGroup has been changed from wrap_content to match_parent, making it take up the entire available width.

- Buttons within the toggle group (bg_color and bg_gradient) now use layout_width="0dp" and layout_weight="1", ensuring they are evenly distributed within the container instead of using wrap_content.

- Unnecessary lines have been removed and the layout has been restructured for better alignment and organization.

- These changes will likely improve usability by making the buttons evenly spaced without requiring horizontal scrolling.