### PR TITLE
fix: refine viewBinding implementation in block selector menu

### DIFF
--- a/app/src/main/java/a/a/a/Fx.java
+++ b/app/src/main/java/a/a/a/Fx.java
@@ -717,7 +717,7 @@ public class Fx {
                 if (isViewBindingEnabled && paramAdapter.startsWith("binding.")) {
                     paramAdapter = paramAdapter.substring("binding.".length());
                 }
-                opcode = String.format("%s.setAdapter(new %s(%s));", param, Lx.a(paramAdapter), params.get(1));
+                opcode = String.format("%s.setAdapter(new %s(%s));", param, Lx.a(paramAdapter, isViewBindingEnabled), params.get(1));
                 break;
             case "listRefresh":
                 opcode = String.format("((BaseAdapter)%s.getAdapter()).notifyDataSetChanged();", params.get(0));

--- a/app/src/main/java/a/a/a/Fx.java
+++ b/app/src/main/java/a/a/a/Fx.java
@@ -8,18 +8,28 @@ import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import mod.hey.studios.editor.manage.block.ExtraBlockInfo;
 import mod.hey.studios.editor.manage.block.v2.BlockLoader;
 import mod.hey.studios.moreblock.ReturnMoreblockManager;
+import mod.pranav.viewbinding.ViewBindingBuilder;
 
 public class Fx {
 
     private static final Pattern PARAM_PATTERN = Pattern.compile("%m(?!\\.[\\w]+)");
     public final boolean isViewBindingEnabled;
+    private final ArrayList<String> viewParamsTypes = new ArrayList<>(List.of(
+            "%m.view", "%m.layout", "%m.textview", "%m.button", "%m.edittext", "%m.imageview", "%m.recyclerview",
+            "%m.listview", "%m.gridview", "%m.cardview", "%m.viewpager", "%m.webview", "%m.videoview", "%m.progressbar",
+            "%m.seekbar", "%m.switch", "%m.checkbox", "%m.spinner", "%m.tablayout", "%m.bottomnavigation", "%m.adview",
+            "%m.swiperefreshlayout", "%m.textinputlayout", "%m.ratingbar", "%m.datepicker", "%m.otpview", "%m.lottie",
+            "%m.badgeview", "%m.codeview", "%m.patternview", "%m.signinbutton", "%m.youtubeview"
+    ));
     public String[] operators = {"repeat", "+", "-", "*", "/", "%", ">", "=", "<", "&&", "||", "not"};
     public String[] arithmetic = {"+", "-", "*", "/", "%", ">", "=", "<", "&&", "||"};
     public String moreBlock = "";
@@ -174,12 +184,34 @@ public class Fx {
 
     public ArrayList<String> getBlockParams(BlockBean bean) {
         ArrayList<String> params = new ArrayList<>();
+        ArrayList<String> paramsTypes = extractParamsTypes(bean.spec);
         for (int i = 0; i < bean.parameters.size(); i++) {
-            String param = bean.parameters.get(i);
+            String param = getParamValue(bean.parameters.get(i), viewParamsTypes.contains(paramsTypes.get(i)));
             int type = getBlockType(bean, i);
             params.add(a(param, type, bean.opCode));
         }
         return params;
+    }
+
+    private String getParamValue(String param, boolean isWidgetParam) {
+        String bindingStart = "binding.";
+        if (isViewBindingEnabled && isWidgetParam && !param.isEmpty() && !param.startsWith(bindingStart)) {
+            return bindingStart + ViewBindingBuilder.generateParameterFromId(param);
+        } else {
+            return param;
+        }
+    }
+
+    private ArrayList<String> extractParamsTypes(String input) {
+        ArrayList<String> matches = new ArrayList<>();
+        Pattern pattern = Pattern.compile("%\\w+(?:\\.\\w+)?|%\\w"); // Supports %m.word.word, %m.word and %word
+        Matcher matcher = pattern.matcher(input);
+
+        while (matcher.find()) {
+            matches.add(matcher.group().toLowerCase());
+        }
+
+        return matches;
     }
 
     private String getBlockCode(BlockBean bean, ArrayList<String> params) {
@@ -191,12 +223,13 @@ public class Fx {
                     opcode = bean.type;
                     moreBlock = "_" + (space < 0 ? bean.spec : bean.spec.substring(0, space)) + "()" + ReturnMoreblockManager.getMbEnd(bean.type);
                 } else {
+                    ArrayList<String> paramsTypes = extractParamsTypes(bean.spec);
                     opcode = "_" + bean.spec.substring(0, space) + "(";
                     boolean hasStringParam = false;
 
                     for (int i = 0; i < params.size(); i++) {
                         if (i > 0) opcode += ", ";
-                        String param = params.get(i);
+                        String param = getParamValue(params.get(i), viewParamsTypes.contains(paramsTypes.get(i)));
                         if (param.isEmpty()) {
                             Gx paramInfo = bean.getParamClassInfo().get(i);
                             if (paramInfo.b("boolean")) {
@@ -1360,12 +1393,13 @@ public class Fx {
         }
         return opcode;
     }
-    
+
     private String getCodeExtraBlock(BlockBean blockBean, String var2) {
         ArrayList<String> parameters = new ArrayList<>();
+        ArrayList<String> paramsTypes = extractParamsTypes(blockBean.spec);
 
         for (int i = 0; i < blockBean.parameters.size(); i++) {
-            String parameterValue = blockBean.parameters.get(i);
+            String parameterValue = getParamValue(blockBean.parameters.get(i), viewParamsTypes.contains(paramsTypes.get(i)));
 
             switch (getBlockType(blockBean, i)) {
                 case 0:
@@ -1432,7 +1466,7 @@ public class Fx {
 
         return formattedCode;
     }
-    
+
     private int getBlockType(BlockBean blockBean, int parameterIndex) {
         int blockType;
 

--- a/app/src/main/java/a/a/a/Jx.java
+++ b/app/src/main/java/a/a/a/Jx.java
@@ -1035,23 +1035,21 @@ public class Jx {
         for (Pair<Integer, String> next2 : projectDataManager.j(javaName)) {
             lists.add(getListDeclarationAndAddImports(next2.first, next2.second));
         }
-        if (!isViewBindingEnabled) {
-            for (ViewBean viewBean : projectDataManager.d(projectFileBean.getXmlName())) {
-                if (!viewBean.convert.equals("include")) {
-                    Set<String> toNotAdd = ox.readAttributesToReplace(viewBean);
-                    if (!toNotAdd.contains("android:id")) {
-                        views.add(getViewDeclarationAndAddImports(viewBean));
-                    }
+        for (ViewBean viewBean : projectDataManager.d(projectFileBean.getXmlName())) {
+            if (!viewBean.convert.equals("include")) {
+                Set<String> toNotAdd = ox.readAttributesToReplace(viewBean);
+                if (!toNotAdd.contains("android:id") && (!isViewBindingEnabled || requireImports(viewBean))) {
+                    views.add(getViewDeclarationAndAddImports(viewBean));
                 }
             }
+        }
 
-            if (projectFileBean.hasActivityOption(ProjectFileBean.OPTION_ACTIVITY_DRAWER)) {
-                for (ViewBean viewBean : projectDataManager.d(projectFileBean.getDrawerXmlName())) {
-                    if (!viewBean.convert.equals("include")) {
-                        Set<String> toNotAdd = ox.readAttributesToReplace(viewBean);
-                        if (!toNotAdd.contains("android:id")) {
-                            views.add(getDrawerViewDeclarationAndAddImports(viewBean));
-                        }
+        if (projectFileBean.hasActivityOption(ProjectFileBean.OPTION_ACTIVITY_DRAWER)) {
+            for (ViewBean viewBean : projectDataManager.d(projectFileBean.getDrawerXmlName())) {
+                if (!viewBean.convert.equals("include")) {
+                    Set<String> toNotAdd = ox.readAttributesToReplace(viewBean);
+                    if (!toNotAdd.contains("android:id") && (!isViewBindingEnabled || requireImports(viewBean))) {
+                        views.add(getDrawerViewDeclarationAndAddImports(viewBean));
                     }
                 }
             }
@@ -1104,6 +1102,26 @@ public class Jx {
         if (hasRewardedVideoAd) {
             fieldsWithStaticInitializers.add(Lx.getComponentFieldCode("RewardedVideoAd"));
         }
+    }
+
+    private boolean requireImports(ViewBean viewBean) {
+        return switch (viewBean.type) {
+            case ViewBean.VIEW_TYPE_WIDGET_LISTVIEW,
+                 ViewBeans.VIEW_TYPE_WIDGET_RECYCLERVIEW,
+                 ViewBeans.VIEW_TYPE_LAYOUT_BOTTOMNAVIGATIONVIEW,
+                 ViewBean.VIEW_TYPE_WIDGET_SPINNER,
+                 ViewBean.VIEW_TYPE_WIDGET_WEBVIEW,
+                 ViewBean.VIEW_TYPE_WIDGET_ADVIEW,
+                 ViewBean.VIEW_TYPE_WIDGET_MAPVIEW,
+                 ViewBeans.VIEW_TYPE_LAYOUT_SWIPEREFRESHLAYOUT,
+                 ViewBeans.VIEW_TYPE_WIDGET_PATTERNLOCKVIEW,
+                 ViewBeans.VIEW_TYPE_WIDGET_CODEVIEW,
+                 ViewBeans.VIEW_TYPE_WIDGET_LOTTIEANIMATIONVIEW,
+                 ViewBeans.VIEW_TYPE_WIDGET_YOUTUBEPLAYERVIEW,
+                 ViewBeans.VIEW_TYPE_LAYOUT_TABLAYOUT,
+                 ViewBeans.VIEW_TYPE_LAYOUT_VIEWPAGER -> true; // it's necessary for the adapters, listeners...
+            default -> false;
+        };
     }
 
     /**

--- a/app/src/main/java/a/a/a/Lx.java
+++ b/app/src/main/java/a/a/a/Lx.java
@@ -256,7 +256,9 @@ public class Lx {
      * @param widgetName The list widget's name
      * @return The adapter's class name (e.g. List_filesAdapter from list_files)
      */
-    public static String a(String widgetName) {
+    public static String a(String widgetName, boolean isViewBindingEnabled) {
+        if (isViewBindingEnabled)
+            widgetName = ViewBindingBuilder.generateParameterFromId(widgetName);
         return widgetName.substring(0, 1).toUpperCase() +
                 widgetName.substring(1) +
                 "Adapter";
@@ -609,7 +611,7 @@ public class Lx {
                             fieldDeclaration = "";
                             break;
                         case "FragmentStatePagerAdapter":
-                            fieldDeclaration += " " + a(typeInstanceName + "Fragment") + " " + typeInstanceName + ";";
+                            fieldDeclaration += " " + a(typeInstanceName + "Fragment", false) + " " + typeInstanceName + ";";
                             break;
                         case "RewardedVideoAd":
                             fieldDeclaration += " RewardedAd " + typeInstanceName + ";";
@@ -802,7 +804,7 @@ public class Lx {
      * @return Code of an adapter for a ListView
      */
     public static String getListAdapterCode(Ox ox, String widgetName, String itemResourceName, ArrayList<ViewBean> views, String onBindCustomViewLogic, boolean isViewBindingEnabled) {
-        String className = a(widgetName);
+        String className = a(widgetName, isViewBindingEnabled);
 
         String initializers = "";
         StringBuilder initializersBuilder = new StringBuilder(initializers);
@@ -1215,7 +1217,7 @@ public class Lx {
                 return componentName + " = new TimePickerDialog(this, " + componentName + "_listener, Calendar.HOUR_OF_DAY, Calendar.MINUTE, false);";
 
             case "FragmentStatePagerAdapter":
-                return componentName + " = new " + a(componentName + "Fragment") + "(getApplicationContext(), getSupportFragmentManager());";
+                return componentName + " = new " + a(componentName + "Fragment", false) + "(getApplicationContext(), getSupportFragmentManager());";
 
             case "Videos":
                 return "file_" + componentName + " = FileUtil.createNewPictureFile(getApplicationContext());\r\n"
@@ -3150,7 +3152,7 @@ public class Lx {
     }
 
     public static String pagerAdapter(Ox ox, String pagerName, String pagerItemLayoutName, ArrayList<ViewBean> pagerItemViews, String onBindCustomViewLogic, boolean isViewBindingEnabled) {
-        String adapterName = a(pagerName);
+        String adapterName = a(pagerName, isViewBindingEnabled);
 
         String viewsInitializer = "";
         StringBuilder viewInitBuilder = new StringBuilder(viewsInitializer);
@@ -3223,6 +3225,12 @@ public class Lx {
                     onBindCustomViewLogic + "\r\n";
         }
 
+        if (isViewBindingEnabled) {
+            baseCode += """
+                    View _view = binding.getRoot();\r
+                    """;
+        }
+
         return baseCode +
                 "\r\n" +
                 "_container.addView(_view);\r\n" +
@@ -3232,7 +3240,7 @@ public class Lx {
     }
 
     public static String recyclerViewAdapter(Ox ox, String recyclerViewName, String itemLayoutName, ArrayList<ViewBean> itemViews, String onBindCustomViewLogic, boolean isViewBindingEnabled) {
-        String adapterName = a(recyclerViewName);
+        String adapterName = a(recyclerViewName, isViewBindingEnabled);
         String viewsInitializer = "";
         StringBuilder viewInitBuilder = new StringBuilder(viewsInitializer);
         for (ViewBean bean : itemViews) {

--- a/app/src/main/java/com/besome/sketch/editor/LogicEditorActivity.java
+++ b/app/src/main/java/com/besome/sketch/editor/LogicEditorActivity.java
@@ -1665,7 +1665,7 @@ public class LogicEditorActivity extends BaseAppCompatActivity implements View.O
         }
         RadioButton radioButton = new RadioButton(this);
         radioButton.setText(type + " : " + id);
-        radioButton.setTag(isViewBindingEnabled ? "binding." + id : id);
+        radioButton.setTag(id);
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (int) (wB.a(this, 1.0f) * 40.0f));
         radioButton.setGravity(Gravity.CENTER | Gravity.LEFT);
         radioButton.setLayoutParams(layoutParams);

--- a/app/src/main/java/mod/agus/jcoderz/editor/event/ManageEvent.java
+++ b/app/src/main/java/mod/agus/jcoderz/editor/event/ManageEvent.java
@@ -775,7 +775,7 @@ public class ManageEvent {
                             listenerLogic + "\r\n" +
                             "};";
             case "FragmentStatePagerAdapter" -> {
-                String className = Lx.a(targetId + "Fragment");
+                String className = Lx.a(targetId + "Fragment", false);
                 yield "public class " + className + " extends FragmentStatePagerAdapter {\r\n" +
                         "// This class is deprecated, you should migrate to ViewPager2:\r\n" +
                         "// https://developer.android.com/reference/androidx/viewpager2/widget/ViewPager2\r\n" +

--- a/app/src/main/res/layout/dialog_project_settings.xml
+++ b/app/src/main/res/layout/dialog_project_settings.xml
@@ -100,7 +100,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
-                        android:text="This will enable ViewBinding in your project. Note: It will require changes on older projects"
+                        android:text="This will enable ViewBinding in your project. Note: Manual changes may be required for widgets used in ASD block"
                         android:textAppearance="?attr/textAppearanceBodyMedium"
                         android:textColor="?attr/colorOnSurfaceVariant" />
 


### PR DESCRIPTION

- Changed the implementation of viewBinding so that `binding.` is no longer stored as part of the id when selecting a widget from the block selector menu. Instead, during source code generation, it checks each param type, and if it's a widget, it dynamically adds `binding.`
  
  - This update allows enabling or disabling the feature anytime without issues, unlike the previous approach, whether for `new or old projects`
  
  - Note: Widgets used in `ASD` will require manual adjustment

  - I've tested it with a big project from Sketchub, and it's working perfectly. Just need to double-check everything to make sure I didn’t miss anything

  - Also fixed a few bugs, like missing imports for some adapters and listeners

