### PR TITLE
Fixed selector edit fonction saving title and name in wrong order

### DIFF
--- a/app/src/main/java/pro/sketchware/fragments/settings/block/selector/BlockSelectorManagerFragment.java
+++ b/app/src/main/java/pro/sketchware/fragments/settings/block/selector/BlockSelectorManagerFragment.java
@@ -149,8 +149,8 @@ public class BlockSelectorManagerFragment extends qA {
                 }
             } else {
                 selectors.set(index, new Selector(
-                        selectorName,
                         selectorTitle,
+                        selectorName,
                         selectors.get(index).getData()
                 ));
             }


### PR DESCRIPTION
fixed an issue where editing a block selector reversed the title and name values