### PR TITLE
Crash fix, Minor UI/text upgrade

### DIFF
--- a/app/src/main/java/pro/sketchware/activities/main/activities/MainActivity.java
+++ b/app/src/main/java/pro/sketchware/activities/main/activities/MainActivity.java
@@ -387,11 +387,31 @@ public class MainActivity extends BasePermissionAppCompatActivity {
     }
 
     @Override
-    public void onPostCreate(Bundle savedInstanceState) {
-        super.onPostCreate(savedInstanceState);
-        drawerToggle.syncState();
-        FirebaseMessaging.getInstance().subscribeToTopic("all");
+public void onPostCreate(Bundle savedInstanceState) {
+    super.onPostCreate(savedInstanceState);
+    drawerToggle.syncState();
+    
+    // Safe Firebase initialization and topic subscription
+    try {
+        // Initialize Firebase if not already initialized
+        if (FirebaseApp.getApps(this).isEmpty()) {
+            FirebaseApp.initializeApp(this);
+        }
+        
+        // Subscribe to topic with error handling
+        FirebaseMessaging.getInstance().subscribeToTopic("all")
+            .addOnCompleteListener(task -> {
+                if (!task.isSuccessful()) {
+                    Exception e = task.getException();
+                    if (e != null) {
+                        Log.e("Firebase", "Subscribe failed", e);
+                    }
+                }
+            });
+    } catch (Exception e) {
+        Log.e("Firebase", "Firebase initialization error", e);
     }
+}
 
     @Override
     public void onResume() {

--- a/app/src/main/java/pro/sketchware/activities/main/activities/MainActivity.java
+++ b/app/src/main/java/pro/sketchware/activities/main/activities/MainActivity.java
@@ -31,6 +31,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.FirebaseApp;
 
 import java.io.File;
 import java.io.IOException;

--- a/app/src/main/res/layout/design_drawer.xml
+++ b/app/src/main/res/layout/design_drawer.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
+        android:scrollbars="none"
         android:fillViewport="true">
 
         <LinearLayout

--- a/app/src/main/res/layout/export_project.xml
+++ b/app/src/main/res/layout/export_project.xml
@@ -91,7 +91,7 @@
                             android:layout_marginTop="2dp"
                             android:textAppearance="?attr/textAppearanceBodySmall"
                             android:textColor="?attr/colorOnSurfaceVariant"
-                            tools:text="Project: MyGreatApp" />
+                            tools:text="Project: MyProject" />
 
                     </LinearLayout>
                 </LinearLayout>
@@ -104,7 +104,7 @@
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
-                <Button
+   ing             <Button
                     android:id="@+id/export_project_button"
                     style="@style/Widget.Material3Expressive.Button"
                     android:layout_width="0dp"
@@ -120,7 +120,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
-                    android:text="Git" />
+                    android:text="Configure" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/export_project.xml
+++ b/app/src/main/res/layout/export_project.xml
@@ -73,7 +73,7 @@
                             android:layout_marginTop="2dp"
                             android:textAppearance="?attr/textAppearanceBodyMedium"
                             android:textColor="?attr/colorOnSurfaceVariant"
-                            tools:text="com.example.package" />
+                            tools:text="com.name.package" />
 
                         <TextView
                             android:id="@+id/project_version_name"
@@ -103,8 +103,7 @@
                 android:layout_marginTop="24dp"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
-
-   ing             <Button
+                <Button
                     android:id="@+id/export_project_button"
                     style="@style/Widget.Material3Expressive.Button"
                     android:layout_width="0dp"


### PR DESCRIPTION
## Crash Fixed
### The **Sketchware Pro was crashing on the MainActivity** on specific devices (g80 processors in my case) 
**Note:** All on every devices (crash)

### **Crashlog**

Sketchware Pro v7.0.0-SNAPSHOT-40d8c9a (150)
base.apk size: 130 MB (129923407 B)
Locale: en_GB
SDK version: 33
Brand: samsung
Manufacturer: samsung
Model: SM-E225F & SM-M325F

``` Error log
java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process pro.sketchware. Make sure to call FirebaseApp.initializeApp(Context) first.
 at com.google.firebase.FirebaseApp.getInstance(FirebaseApp.java:179)
 at com.google.firebase.messaging.FirebaseMessaging.getInstance(FirebaseMessaging.java:120)
 at pro.sketchware.activities.main.activities.MainActivity.onPostCreate(MainActivity.java:393)
 at android.app.Instrumentation.callActivityOnPostCreate(Instrumentation.java:1458)
 at android.app.ActivityThread.handleStartActivity(ActivityThread.java:4231)
 at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
 at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
 at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
 at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
 at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2574)
 at android.os.Handler.dispatchMessage(Handler.java:106)
 at android.os.Looper.loopOnce(Looper.java:226)
 at android.os.Looper.loop(Looper.java:313)
 at android.app.ActivityThread.main(ActivityThread.java:8779)
 at java.lang.reflect.Method.invoke(Native Method)
 at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

### **Removed: Scrollbar from DesignActivity drawer**

**Button wrong text Fixed**
**And other useless text changed**