### PR TITLE
fix: resolve formating behaviour in Code editor

### DIFF
--- a/app/src/main/java/mod/hilal/saif/asd/AsdDialog.java
+++ b/app/src/main/java/mod/hilal/saif/asd/AsdDialog.java
@@ -49,7 +49,7 @@ public class AsdDialog extends Dialog implements DialogInterface.OnDismissListen
         }
 
         binding.editor.setTypefaceText(EditorUtils.getTypeface(act));
-        binding.editor.setText(Lx.j(content, false));
+        binding.editor.setText(content);
         binding.editor.setWordwrap(false);
 
         EditorUtils.loadJavaConfig(binding.editor);


### PR DESCRIPTION
this will solve the duplicate usage of the formatter each time the editor opned