### PR TITLE
fix: crash dialog is now uncancelable

### DIFF
--- a/app/src/main/java/com/besome/sketch/tools/CollectErrorActivity.java
+++ b/app/src/main/java/com/besome/sketch/tools/CollectErrorActivity.java
@@ -43,6 +43,7 @@ public class CollectErrorActivity extends BaseAppCompatActivity {
                     .setPositiveButton("Copy", null)
                     .setNegativeButton("Cancel", (dialogInterface, which) -> finish())
                     .setNeutralButton("Show error", null) // null to set proper onClick listeners later without dismissing the AlertDialog
+                    .setCancelable(false)
                     .show();
 
             TextView messageView = dialog.findViewById(android.R.id.message);


### PR DESCRIPTION
The crash dialog is not longer cancelable.