### PR TITLE
Security Fix: Potential Path Traversal Vulnerability in extractZipTo function

### DIFF
--- a/app/src/main/java/pro/sketchware/utility/FileUtil.java
+++ b/app/src/main/java/pro/sketchware/utility/FileUtil.java
@@ -784,11 +784,15 @@ public class FileUtil {
 
         ZipEntry entry = input.getNextEntry();
         while (entry != null) {
-            String entryPathExtracted = new File(outPath, entry.getName()).getAbsolutePath();
+            File destFile = new File(outPath, entry.getName());
+            // Validate the file path to prevent path traversal
+            if (!destFile.toPath().normalize().startsWith(outDir.toPath().normalize())) {
+                throw new IOException("Bad zip entry: " + entry.getName());
+            }
 
             if (!entry.isDirectory()) {
-                new File(entryPathExtracted).getParentFile().mkdirs();
-                writeBytes(new File(entryPathExtracted), readFromInputStream(input));
+                destFile.getParentFile().mkdirs();
+                writeBytes(destFile, readFromInputStream(input));
             }
             input.closeEntry();
             entry = input.getNextEntry();


### PR DESCRIPTION
This PR addresses a potential vulnerability in the extractZipTo() function in FileUtil.java that could lead to path traversal attacks as malicious ZIP entries could escape the intended directory (outPath). This issue was originally reported and resolved in the repository via this commit https://github.com/restx/restx/commit/86fe421db112cea8199615b299abccbe1b148394.

**Fix**

- **Validate the Extracted File Path**
   - Add a check to ensure that the extracted file path is within the intended directory


**References**
CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
https://github.com/restx/restx/commit/86fe421db112cea8199615b299abccbe1b148394