### PR TITLE
Fix when using source code for Android Studio

### DIFF
--- a/app/src/main/java/a/a/a/Lx.java
+++ b/app/src/main/java/a/a/a/Lx.java
@@ -89,13 +89,13 @@ public class Lx {
         List<BuiltInLibraries.BuiltInLibrary> excludedLibraries = ExcludeBuiltInLibrariesActivity.getExcludedLibraries(metadata.sc_id);
         if (isLibraryNotExcluded(BuiltInLibraries.ANDROIDX_APPCOMPAT, excludedLibraries) && metadata.g) {
             content.append("""
-                    implementation 'androidx.appcompat:appcompat:1.7.0'\r
+                    implementation 'androidx.appcompat:appcompat:1.7.1'\r
                     implementation 'com.google.android.material:material:1.12.0'\r
                     """);
         }
 
         if (metadata.isFirebaseEnabled) {
-            content.append("implementation platform('com.google.firebase:firebase-bom:33.4.0')\r\n");
+            content.append("implementation platform('com.google.firebase:firebase-bom:34.1.0')\r\n");
         }
 
         if (isLibraryNotExcluded(BuiltInLibraries.FIREBASE_AUTH, excludedLibraries) && metadata.isFirebaseAuthUsed) {
@@ -1608,7 +1608,6 @@ public class Lx {
                 "    repositories {\r\n" +
                 "        google()\r\n" +
                 "        mavenCentral()\r\n" +
-                "        jcenter()\r\n" +
                 "    }\r\n" +
                 "    dependencies {\r\n" +
                 "        classpath 'com.android.tools.build:gradle:" + androidGradlePluginVersion + "'\r\n" +
@@ -1622,7 +1621,6 @@ public class Lx {
                 "    repositories {\r\n" +
                 "        google()\r\n" +
                 "        mavenCentral()\r\n" +
-                "        jcenter()\r\n" +
                 "    }\r\n" +
                 "}\r\n" +
                 "\r\n" +

--- a/app/src/main/java/a/a/a/yq.java
+++ b/app/src/main/java/a/a/a/yq.java
@@ -304,7 +304,7 @@ public class yq {
         fileUtil.b(projectMyscPath + File.separator + "app" + File.separator + "build.gradle",
                 Lx.getBuildGradleString(VAR_DEFAULT_TARGET_SDK_VERSION, VAR_DEFAULT_MIN_SDK_VERSION, projectSettings.getValue(ProjectSettings.SETTING_TARGET_SDK_VERSION, String.valueOf(VAR_DEFAULT_TARGET_SDK_VERSION)), N, projectSettings.getValue(ProjectSettings.SETTING_ENABLE_VIEWBINDING, ProjectSettings.SETTING_GENERIC_VALUE_FALSE).equals(ProjectSettings.SETTING_GENERIC_VALUE_TRUE)));
         fileUtil.b(projectMyscPath + File.separator + "settings.gradle", Lx.a());
-        fileUtil.b(projectMyscPath + File.separator + "build.gradle", Lx.c("8.7.0", "4.4.2"));
+        fileUtil.b(projectMyscPath + File.separator + "build.gradle", Lx.c("8.12.0", "4.4.3"));
 
         fileUtil.b(projectMyscPath + File.separator + "gradle.properties", """
                 android.enableR8.fullMode=false


### PR DESCRIPTION
`feat: Set appcompat version to 1.7.1 in Lx.getBuildGradleString.`
`feat: Set firebase-bom version to 34.1.0 in Lx.getBuildGradleString.`
`feat: Set gradle version to 8.12.0 in yq.h.`
`feat: Set google-services version to 4.4.3 in yq.h.`
`feat: Removed JCenter in Lx.c.`

Some things are outdated and cause errors when used on Android Studio.