### PR TITLE
Fix drawer being empty at the bottom half. Because the keyboard is in the previous project creation activity.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,7 @@
         <activity
             android:name="com.besome.sketch.design.DesignActivity"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|keyboard"
+            android:windowSoftInputMode="stateHidden"
             android:theme="@style/Theme.SketchwarePro.SmallToolbar" />
         <activity
             android:name="pro.sketchware.activities.main.activities.MainActivity"


### PR DESCRIPTION
`fix: Fix drawer being empty at the bottom half. Because the keyboard is in the previous project creation activity.`
https://github.com/Sketchware-Pro/Sketchware-Pro/issues/1797