### PR TITLE
featuring latest material dependencies update of alpha channel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.viewpager:viewpager:1.1.0"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation "com.google.android.material:material:1.14.0-alpha01"
+    implementation "com.google.android.material:material:1.14.0-alpha04"
     implementation "com.airbnb.android:lottie:6.5.2"
     implementation "com.google.android.flexbox:flexbox:3.0.0"
 


### PR DESCRIPTION
What’s new in Material 1.14.0-alpha02 → 1.14.0-alpha04?

1. 1.14.0-alpha02 — Jun 18, 2025

compileSdk → 35.

androidx.core bumped; dependency updates.

AppBar / BottomSheet bug fixes + accessibility (half-expanded state).

Catalog/demo fixes; HideOnScrollBehavior fixes. 



2. 1.14.0-alpha03 — Jul 21, 2025

compileSdk 35 note.

BottomSheet handle keyboard support.

Accessibility & demo updates; LoadingIndicator static drawable + animation fixes.

MaterialCardView keyboard selection; ProgressIndicator API improvements. 



3. 1.14.0-alpha04 — Aug 20, 2025

ExposedDropdownMenu keyboard support.

Lists: segmented list style + ListItemViewHolder/demo.

LoadingIndicator: showDelay & minHideDelay.

TextInputLayout/tooltips, TimePicker keyboard support, TopAppBar nav circle background.

AGP & Gradle bumps. 

Sources: GitHub release notes + Maven listing.