### PR TITLE
fix(timer): add null check before calling cancel()

### DIFF
--- a/app/src/main/java/a/a/a/Fx.java
+++ b/app/src/main/java/a/a/a/Fx.java
@@ -904,7 +904,7 @@ public class Fx {
                 opcode = String.format("%s = new TimerTask() {\n@Override\npublic void run() {\nrunOnUiThread(new Runnable() {\n@Override\npublic void run() {\n%s\n}\n});\n}\n};\n_timer.scheduleAtFixedRate(%s, (int)(%s), (int)(%s));", params.get(0), onRun, params.get(0), params.get(1), params.get(2));
                 break;
             case "timerCancel":
-                opcode = String.format("%s.cancel();", params.get(0));
+                opcode = String.format("if (%s != null) { %s.cancel(); }", params.get(0), params.get(0));
                 break;
             case "firebaseAdd":
                 opcode = String.format("%s.child(%s).updateChildren(%s);", params.get(0), params.get(1), params.get(2));


### PR DESCRIPTION
IPreviously, the generated code for the Timer Cancel block was:

    cc.cancel();

This could throw a NullPointerException if the timer variable was not initialized or already cancelled.

Now the generated code is:

    if (cc != null) { cc.cancel(); }

This ensures the block works safely and prevents crashes when the timer reference is null.