### PR TITLE
feat: Sort local libraries to show enabled ones first

### DIFF
--- a/app/src/main/java/dev/aldi/sayuti/editor/manage/ManageLocalLibraryActivity.java
+++ b/app/src/main/java/dev/aldi/sayuti/editor/manage/ManageLocalLibraryActivity.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executors;
+import java.util.Comparator;
 
 import a.a.a.MA;
 import a.a.a.mB;
@@ -281,12 +282,7 @@ public class ManageLocalLibraryActivity extends BaseAppCompatActivity {
             projectUsedLibs = getLocalLibraries(scId);
         }
 
-        //This code helps in sorting the list of local libraries to display enabled libraries first.
-        java.util.Collections.sort(localLibraries, (lib1, lib2) -> {
-            boolean isEnabled1 = isUsedLibrary(lib1.getName());
-            boolean isEnabled2 = isUsedLibrary(lib2.getName());
-            return Boolean.compare(isEnabled2, isEnabled1);
-        });
+        localLibraries.sort(Comparator.comparing(lib -> !isUsedLibrary(lib.getName())));
 
         runOnUiThread(() -> {
             adapter.setLocalLibraries(localLibraries);
@@ -563,13 +559,9 @@ public class ManageLocalLibraryActivity extends BaseAppCompatActivity {
                     }
                 }
             }
-            // Sorts the filtered search results to ensure enabled libraries still appear at the top.
-            java.util.Collections.sort(filteredLocalLibraries, (lib1, lib2) -> {
-                boolean isEnabled1 = isUsedLibrary(lib1.getName());
-                boolean isEnabled2 = isUsedLibrary(lib2.getName());
-                return Boolean.compare(isEnabled2, isEnabled1);
-            });
-
+            
+            filteredLocalLibraries.sort(Comparator.comparing(lib -> !isUsedLibrary(lib.getName())));
+            
             notifyDataSetChanged();
         }
 


### PR DESCRIPTION
This commit updates the Local Library Manager to display enabled libraries at the top of the list. The sorting is applied both to the initial list display and to the filtered results when using the search functionality.

The following file was modified:
- `app/src/main/java/dev/aldi/sayuti/editor/manage/ManageLocalLibraryActivity.java`