### PR TITLE
fix: enable keyboard for find/replace in AsdDialog

### DIFF
--- a/app/src/main/java/mod/hilal/saif/asd/AsdDialog.java
+++ b/app/src/main/java/mod/hilal/saif/asd/AsdDialog.java
@@ -31,7 +31,7 @@ public class AsdDialog extends Dialog implements DialogInterface.OnDismissListen
     private String content;
 
     public AsdDialog(Activity activity) {
-        super(activity);
+        super(activity, R.style.AsdEditorDialogTheme);
         act = activity;
     }
 
@@ -45,7 +45,7 @@ public class AsdDialog extends Dialog implements DialogInterface.OnDismissListen
         Window window = getWindow();
         if (window != null) {
             window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            //window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         }
 
         binding.editor.setTypefaceText(EditorUtils.getTypeface(act));

--- a/app/src/main/res/values/styles_new.xml
+++ b/app/src/main/res/values/styles_new.xml
@@ -141,4 +141,12 @@
     <style name="ThemeOverlay.SketchwarePro.Chip.ProjectPreview" parent="">
         <item name="chipStyle">@style/Widget.SketchwarePro.Chip.ProjectPreview</item>
     </style>
+    <!-- Theme used by AsdDialog to fix keyboard visibility for find/replace -->
+    <style name="AsdEditorDialogTheme" parent="Theme.SketchwarePro">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowFullscreen">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowSoftInputMode">stateVisible|adjustResize</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Dialog</item>
+    </style>
 </resources>


### PR DESCRIPTION
### Fix keyboard issue in AsdDialog find/replace

This PR fixes an issue where the keyboard could not be opened when using the find/replace feature in `AsdDialog`.

### Changes
- Added `AsdEditorDialogTheme` in `styles_new.xml`
- Set `android:windowSoftInputMode` to `stateVisible|adjustResize`
- Applied the theme to `AsdDialog`

### Result
The keyboard can now open when using the find/replace search field.

### Files Modified
- `styles_new.xml`
- `AsdDialog.java`