### PR TITLE
fix: prevent NPE in XmlBuilder.AttributeBuilder.toCode() when newline…

### DIFF
--- a/app/src/main/java/pro/sketchware/xml/XmlBuilder.java
+++ b/app/src/main/java/pro/sketchware/xml/XmlBuilder.java
@@ -132,7 +132,7 @@ public class XmlBuilder {
             if (namespace != null && !namespace.isEmpty()) {
                 return namespace + ":" + attr + "=" + "\"" + value + "\"";
             } else if (attr == null || attr.length() <= 0) {
-                return value.replaceAll("\n", g);
+                return g != null ? value.replaceAll("\n", g) : value;
             } else {
                 return attr + "=" + "\"" + value + "\"";
             }


### PR DESCRIPTION
… indent is null

When an XmlBuilder node has only one attribute (or uses inline attributes), the newline indent field g is never assigned, remaining null. If that attribute is a value-only attribute (added via addAttributeValue()), the toCode() method calls value.replaceAll('\n', g) with g=null, which crashes when the value contains a newline character.

This can happen when Android Manifest injection attributes override both android:name and android:configChanges for an activity, leaving the XmlBuilder node with only value-only attributes.

Fix: guard the replaceAll call with a null check on g, returning the raw value when no newline indentation is needed.