### PR TITLE
fix: correct Videos intent generation and LogicHandler file writing

### DIFF
--- a/app/src/main/java/a/a/a/Lx.java
+++ b/app/src/main/java/a/a/a/Lx.java
@@ -1208,6 +1208,7 @@ public class Lx {
                         + "}\r\n"
                         + "else {\r\n"
                         + "_uri_" + componentName + " = Uri.fromFile(file_" + componentName + ");\r\n"
+                        + "}\r\n"
                         + componentName + ".putExtra(MediaStore.EXTRA_OUTPUT, _uri_" + componentName + ");\r\n"
                         + componentName + ".addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);";
 

--- a/app/src/main/java/mod/hilal/saif/events/LogicHandler.java
+++ b/app/src/main/java/mod/hilal/saif/events/LogicHandler.java
@@ -99,7 +99,7 @@ public class LogicHandler {
                     newStr = newStr.concat("\n").concat(arr2.get(i));
                 }
             }
-            FileUtil.writeFile(newStr, FileUtil.getExternalStorageDir().concat("/.sketchware/data/system/temp/").concat(javaName));
+            FileUtil.writeFile(FileUtil.getExternalStorageDir().concat("/.sketchware/data/system/temp/").concat(javaName), newStr);
         } catch (Exception ignored) {
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes two verified bugs in upstream `main`:

1. `Videos` component code generation emitted invalid Java:
   - the generated `else` block was missing its closing brace
   - `putExtra(MediaStore.EXTRA_OUTPUT, ...)` and `addFlags(...)` were emitted only inside the `else` branch

2. [LogicHandler.android()](cci:1://file:///C:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/mod/hilal/saif/events/LogicHandler.java:75:4-104:5) passed `FileUtil.writeFile()` arguments in the wrong order:
   - current call: `writeFile(content, path)`
   - actual signature: `writeFile(path, content)`

## Root cause

### Videos component
The generated code for `Videos` diverged from the working `Camera` implementation:
- the `else` block was not closed
- intent configuration was placed inside the legacy branch instead of after the URI selection

This could produce invalid generated Java and also skip `EXTRA_OUTPUT` / URI permission flags on newer Android versions.

### LogicHandler
[LogicHandler.android()](cci:1://file:///C:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/mod/hilal/saif/events/LogicHandler.java:75:4-104:5) assembled the extracted manifest-related code correctly, but wrote it using reversed parameters, causing the content string to be treated as a file path.

## Fix

- In [a/a/a/Lx.java](cci:7://file:///C:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/a/a/a/Lx.java:0:0-0:0)
  - close the `else` block properly
  - move `putExtra(...)` and `addFlags(...)` outside the `if/else`

- In [mod/hilal/saif/events/LogicHandler.java](cci:7://file:///C:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/mod/hilal/saif/events/LogicHandler.java:0:0-0:0)
  - change `FileUtil.writeFile(newStr, path)` to `FileUtil.writeFile(path, newStr)`

## Validation

Both issues were reproduced and minimally verified on a clean branch matching upstream `main`.

### Videos
- Reproduced the generated `Videos` snippet separately
- Confirmed the original form fails compilation with `javac`
- Confirmed the fixed form compiles successfully

### LogicHandler
- Reproduced the original argument order with a minimal runtime test
- Confirmed it throws `FileNotFoundException` and does not create the intended output file
- Confirmed the fixed order creates the expected file and writes the correct content

## Files changed

- [app/src/main/java/a/a/a/Lx.java](cci:7://file:///C:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/a/a/a/Lx.java:0:0-0:0)
- [app/src/main/java/mod/hilal/saif/events/LogicHandler.java](cci:7://file:///C:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/mod/hilal/saif/events/LogicHandler.java:0:0-0:0)