### PR TITLE
fix: prevent double-context wrapping of getSharedPreferences in fragments

### DIFF
--- a/app/src/main/java/a/a/a/Jx.java
+++ b/app/src/main/java/a/a/a/Jx.java
@@ -590,7 +590,7 @@ public class Jx {
                     .replaceAll("\\(SensorManager\\) getSystemService", "(SensorManager) getContext().getSystemService")
                     .replaceAll("Typeface.createFromAsset\\(getAssets\\(\\)", "Typeface.createFromAsset(getContext().getAssets()")
                     .replaceAll("= getAssets\\(\\).open", "= getContext().getAssets().open")
-                    .replaceAll("getSharedPreferences", "getContext().getSharedPreferences")
+                    .replaceAll("(?<!\\.)getSharedPreferences", "getContext().getSharedPreferences")
                     .replaceAll("AlertDialog.Builder\\(this\\);", "AlertDialog.Builder(getActivity());")
                     .replaceAll("SpeechRecognizer.createSpeechRecognizer\\(this\\);", "SpeechRecognizer.createSpeechRecognizer(getContext());")
                     .replaceAll("new RequestNetwork\\(this\\);", "new RequestNetwork((Activity) getContext());")


### PR DESCRIPTION
## Summary

- `Jx.java` applies a chain of `replaceAll()` calls to adapt Activity code for Fragment screens.
- The `getSharedPreferences` replacement was too broad: it matched even when the call was already prefixed by `getActivity().`, transforming `getActivity().getSharedPreferences(...)` into `getActivity().getContext().getSharedPreferences(...)`.
- `FragmentActivity`/`Activity` has no `getContext()` method, so this caused a compile error: *"The method getContext() is undefined for the type FragmentActivity"*.
- Fixed by adding a negative lookbehind `(?<!\.)` so the replacement only fires on bare `getSharedPreferences(...)` calls, not ones already chained on an object.

## Root cause (one-liner)
```java
// Before (too broad — also matches getActivity().getSharedPreferences)
.replaceAll("getSharedPreferences", "getContext().getSharedPreferences")

// After (negative lookbehind skips calls already prefixed with ".")
.replaceAll("(?<!\\.)getSharedPreferences", "getContext().getSharedPreferences")
```

## Test plan
- [ ] Create a Fragment screen in Sketchware Pro
- [ ] Add a SharedPreferences block using `getSharedPreferences(...)` directly — should compile to `getContext().getSharedPreferences(...)`
- [ ] Add custom code using `getActivity().getSharedPreferences(...)` — should remain unchanged and compile without error
- [ ] Verify no regression on Activity screens (non-Fragment code path is not affected)

Closes #1993

🤖 Generated with [Claude Code](https://claude.com/claude-code)
